### PR TITLE
Fix for #25

### DIFF
--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -91,11 +91,11 @@ class DayOfMonthField extends AbstractField
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {
-            $date->sub(new DateInterval('P1D'));
-            $date->setTime(23, 59, 0);
+            $date->modify('previous day');
+            $date->setTime(23,59);
         } else {
-            $date->add(new DateInterval('P1D'));
-            $date->setTime(0, 0, 0);
+            $date->modify('next day');
+            $date->setTime(0,0);
         }
 
         return $this;

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -110,10 +110,10 @@ class DayOfWeekField extends AbstractField
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {
-            $date->sub(new DateInterval('P1D'));
-            $date->setTime(23, 59, 0);
+            $date->modify('-1 day');
+            $date->setTime(23, 59, 0);    
         } else {
-            $date->add(new DateInterval('P1D'));
+            $date->modify('+1 day');
             $date->setTime(0, 0, 0);
         }
 

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -4,6 +4,7 @@ namespace Cron;
 
 use DateTime;
 use DateInterval;
+use DateTimeZone;
 
 /**
  * Hours field.  Allows: * , / -
@@ -25,13 +26,21 @@ class HoursField extends AbstractField
      */
     public function increment(DateTime $date, $invert = false)
     {
+        /**
+         * Change timezone to UTC temporarily. This will
+         * allow us to go back or forwards and hour even
+         * if DST will be changed between the hours.
+         */
+        $timezone = $date->getTimezone();
+        $date->setTimezone(new DateTimeZone('UTC'));
         if ($invert) {
-            $date->sub(new DateInterval('PT1H'));
-            $date->setTime($date->format('H'), 59, 0);
+            $date->modify('-1 hour');
+            $date->setTime($date->format('H'), 59);
         } else {
-            $date->add(new DateInterval('PT1H'));
-            $date->setTime($date->format('H'), 0, 0);
+            $date->modify('+1 hour');
+            $date->setTime($date->format('H'), 0);
         }
+        $date->setTimezone($timezone);
 
         return $this;
     }

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -26,9 +26,9 @@ class MinutesField extends AbstractField
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {
-            $date->sub(new DateInterval('PT1M'));
+            $date->modify('-1 minute');
         } else {
-            $date->add(new DateInterval('PT1M'));
+            $date->modify('+1 minute');
         }
 
         return $this;

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -35,24 +35,12 @@ class MonthField extends AbstractField
      */
     public function increment(DateTime $date, $invert = false)
     {
-        $year = $date->format('Y');
         if ($invert) {
-            $month = $date->format('m') - 1;
-            if ($month < 1) {
-                $month = 12;
-                $year--;
-            }
-            $date->setDate($year, $month, 1);
-            $date->setDate($year, $month, $date->format('t'));
-            $date->setTime(23, 59, 0);
+            $date->modify('last day of previous month');
+            $date->setTime(23,59);
         } else {
-            $month = $date->format('m') + 1;
-            if ($month > 12) {
-                $month = 1;
-                $year++;
-            }
-            $date->setDate($year, $month, 1);
-            $date->setTime(0, 0, 0);
+            $date->modify('first day of next month');
+            $date->setTime(0,0);
         }
 
         return $this;

--- a/src/Cron/YearField.php
+++ b/src/Cron/YearField.php
@@ -26,11 +26,11 @@ class YearField extends AbstractField
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {
-            $date->sub(new DateInterval('P1Y'));
+            $date->modify('-1 year');
             $date->setDate($date->format('Y'), 12, 31);
             $date->setTime(23, 59, 0);
         } else {
-            $date->add(new DateInterval('P1Y'));
+            $date->modify('+1 year');
             $date->setDate($date->format('Y'), 1, 1);
             $date->setTime(0, 0, 0);
         }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -273,4 +273,13 @@ class CronExpressionTest extends \PHPUnit_Framework_TestCase
         $cron = CronExpression::factory('0 0 27 JAN *');
         $this->assertEquals('2011-01-27 00:00:00', $cron->getPreviousRunDate('2011-08-22 00:00:00')->format('Y-m-d H:i:s'));
     }
+	
+	public function testIssue29()
+	{
+		$cron = CronExpression::factory('@weekly');
+		$this->assertEquals(
+			'2013-03-10 00:00:00',
+			$cron->getPreviousRunDate('2013-03-17 00:00:00')->format('Y-m-d H:i:s')
+		);
+	}
 }


### PR DESCRIPTION
Cleaned up some of the code to use date->modify. The reason for this is because PHP has a bug with adding time and then setting the time. See https://bugs.php.net/bug.php?id=51090. Using modify appears to work around this issue.

The primary problem for #25 was that DST was being observed on the date in question. When the script would subtract 1 hour, it would reset back to the current hour.

The solution was to temporarily set the timezone to UTC when subtracting hours. UTC does not observe DST.

Signed-off-by: Kyle Kirby kylekirby@optimalconnection.net
