### PR TITLE
Allow multiple spaces and even tabs to be schedula separators

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -101,21 +101,15 @@ class CronExpression
      */
     public function setExpression($value)
     {
-        if (!preg_match('/^([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)(?:\s+([^\s]+))?$/', $value, $matches)) {
+        $this->cronParts = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        if (count($this->cronParts) < 5) {
             throw new InvalidArgumentException(
                 $value . ' is not a valid CRON expression'
             );
         }
 
-        $this->setPart(self::MINUTE, $matches[1]);
-        $this->setPart(self::HOUR, $matches[2]);
-        $this->setPart(self::DAY, $matches[3]);
-        $this->setPart(self::MONTH, $matches[4]);
-        $this->setPart(self::WEEKDAY, $matches[5]);
-
-        // Also fetch year if set
-        if (isset($matches[6])) {
-            $this->setPart(self::YEAR, $matches[6]);
+        foreach ($this->cronParts as $position => $part) {
+            $this->setPart($position, $part);
         }
 
         return $this;

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -55,7 +55,7 @@ class CronExpressionTest extends \PHPUnit_Framework_TestCase
     {
         $cron = CronExpression::factory($schedule);
         $this->assertEquals($expected[0], $cron->getExpression(CronExpression::MINUTE));
-        $this->assertEquals($expedted[1], $cron->getExpression(CronExpression::HOUR));
+        $this->assertEquals($expected[1], $cron->getExpression(CronExpression::HOUR));
         $this->assertEquals($expected[2], $cron->getExpression(CronExpression::DAY));
         $this->assertEquals($expected[3], $cron->getExpression(CronExpression::MONTH));
         $this->assertEquals($expected[4], $cron->getExpression(CronExpression::WEEKDAY));


### PR DESCRIPTION
Hi,

first of all, thanks for this great tool! :-)
I'm sending you this pull request in order to fix something I'd call a bug: Crontab schedules allow multiple spaces and also tabs to be separators of single schedule parts.

However, as cron-expression split by a single space, this syntax was not supported.

I've fixed this using a simple regex.

Feel free to accept my pull request in case you're agreeing with me that cron-expression should support this feature.

Greetings,
Daniel
