### PR TITLE
new static instead of self

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -76,7 +76,7 @@ class CronExpression
             $expression = $mappings[$expression];
         }
 
-        return new self($expression, $fieldFactory ?: new FieldFactory());
+        return new static($expression, $fieldFactory ?: new FieldFactory());
     }
 
     /**


### PR DESCRIPTION
when extending CronExpression, new self() will return a \Cron\CronExpression object instead of whatever extends it. This PR solved that problem by doing a new static() instead.
