### PR TITLE
Avoid infinity loop & division by zero

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 5.5
   - 5.6
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: hhvm

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -77,7 +77,7 @@ abstract class AbstractField implements FieldInterface
     {
         $parts = array_map('trim', explode('/', $value, 2));
         $stepSize = isset($parts[1]) ? $parts[1] : 0;
-        if ($parts[0] == '*' || $parts[0] === '0') {
+        if (($parts[0] == '*' || $parts[0] === '0') && 0 !== $stepSize) {
             return (int) $dateValue % $stepSize == 0;
         }
 
@@ -87,6 +87,10 @@ abstract class AbstractField implements FieldInterface
         // Ensure that the date value is within the range
         if ($dateValue < $offset || $dateValue > $to) {
             return false;
+        }
+
+        if ($dateValue > $offset && 0 === $stepSize) {
+          return false;
         }
 
         for ($i = $offset; $i <= $to; $i+= $stepSize) {

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -42,8 +42,8 @@ class CronExpression
      * Factory method to create a new CronExpression.
      *
      * @param string $expression The CRON expression to create.  There are
-     *      several special predefined values which can be used to substitute the
-     *      CRON expression:
+     *                           several special predefined values which can be used to substitute the
+     *                           CRON expression:
      *
      *      `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
      *      `@monthly` - Run once a month, midnight, first of month - 0 0 1 * *
@@ -133,15 +133,15 @@ class CronExpression
     /**
      * Get a next run date relative to the current date or a specific date
      *
-     * @param string|\DateTime $currentTime Relative calculation date
-     * @param int             $nth          Number of matches to skip before returning a
-     *     matching next run date.  0, the default, will return the current
-     *     date and time if the next run date falls on the current date and
-     *     time.  Setting this value to 1 will skip the first match and go to
-     *     the second match.  Setting this value to 2 will skip the first 2
-     *     matches and so on.
-     * @param bool $allowCurrentDate Set to TRUE to return the current date if
-     *     it matches the cron expression.
+     * @param string|\DateTime $currentTime      Relative calculation date
+     * @param int              $nth              Number of matches to skip before returning a
+     *                                           matching next run date.  0, the default, will return the current
+     *                                           date and time if the next run date falls on the current date and
+     *                                           time.  Setting this value to 1 will skip the first match and go to
+     *                                           the second match.  Setting this value to 2 will skip the first 2
+     *                                           matches and so on.
+     * @param bool             $allowCurrentDate Set to TRUE to return the current date if
+     *                                           it matches the cron expression.
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
@@ -154,10 +154,10 @@ class CronExpression
     /**
      * Get a previous run date relative to the current date or a specific date
      *
-     * @param string|\DateTime $currentTime     Relative calculation date
-     * @param int             $nth              Number of matches to skip before returning
-     * @param bool            $allowCurrentDate Set to TRUE to return the
-     *     current date if it matches the cron expression
+     * @param string|\DateTime $currentTime      Relative calculation date
+     * @param int              $nth              Number of matches to skip before returning
+     * @param bool             $allowCurrentDate Set to TRUE to return the
+     *                                           current date if it matches the cron expression
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
@@ -171,11 +171,11 @@ class CronExpression
     /**
      * Get multiple run dates starting at the current date or a specific date
      *
-     * @param int             $total            Set the total number of dates to calculate
-     * @param string|\DateTime $currentTime     Relative calculation date
-     * @param bool            $invert           Set to TRUE to retrieve previous dates
-     * @param bool            $allowCurrentDate Set to TRUE to return the
-     *     current date if it matches the cron expression
+     * @param int              $total            Set the total number of dates to calculate
+     * @param string|\DateTime $currentTime      Relative calculation date
+     * @param bool             $invert           Set to TRUE to retrieve previous dates
+     * @param bool             $allowCurrentDate Set to TRUE to return the
+     *                                           current date if it matches the cron expression
      *
      * @return array Returns an array of run dates
      */
@@ -193,10 +193,10 @@ class CronExpression
      * Get all or part of the CRON expression
      *
      * @param string $part Specify the part to retrieve or NULL to get the full
-     *     cron schedule string.
+     *                     cron schedule string.
      *
      * @return string|null Returns the CRON expression, a part of the
-     *      CRON expression, or NULL if the part was specified but not found
+     *                     CRON expression, or NULL if the part was specified but not found
      */
     public function getExpression($part = null)
     {
@@ -252,11 +252,11 @@ class CronExpression
     /**
      * Get the next or previous run date of the expression relative to a date
      *
-     * @param string|\DateTime $currentTime     Relative calculation date
-     * @param int             $nth              Number of matches to skip before returning
-     * @param bool            $invert           Set to TRUE to go backwards in time
-     * @param bool            $allowCurrentDate Set to TRUE to return the
-     *     current date if it matches the cron expression
+     * @param string|\DateTime $currentTime      Relative calculation date
+     * @param int              $nth              Number of matches to skip before returning
+     * @param bool             $invert           Set to TRUE to go backwards in time
+     * @param bool             $allowCurrentDate Set to TRUE to return the
+     *                                           current date if it matches the cron expression
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -113,6 +113,7 @@ class DayOfWeekField extends AbstractField
     public function validate($value)
     {
         $value = $this->convertLiterals($value);
+
         return (bool) preg_match('/^(\*|[0-7](L?|#[1-5]))([\/\,\-][0-7]+)*$/', $value);
     }
 

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -58,6 +58,9 @@ class AbstractFieldTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($f->isInIncrementsOfRanges(2, '3-59/13'));
         $this->assertFalse($f->isInIncrementsOfRanges(14, '*/13'));
         $this->assertFalse($f->isInIncrementsOfRanges(14, '3-59/2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '2-59'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '*'));
 
         $this->assertTrue($f->isInIncrementsOfRanges(4, '4/10'));
         $this->assertTrue($f->isInIncrementsOfRanges(14, '4/10'));


### PR DESCRIPTION
This is of course to handle bad input parameters for `isInIncrementsOfRanges`.

This fix #64

I've also run `php-cs-fixer` to cleanup few things. If you're not ok with that, I can revert change related to it.
