### PR TITLE
fix DayOfWeekField::validate() for multiple days with week of month, like MON#1,MON#3

### DIFF
--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -113,6 +113,16 @@ class DayOfWeekField extends AbstractField
     public function validate($value)
     {
         $value = $this->convertLiterals($value);
+        if (strpos($value, ',')) {
+            $values = explode(',', $value);
+            foreach ($values as $value) {
+                if (!$this->validate($value)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         return (bool) preg_match('/^(\*|[0-7](L?|#[1-5]))([\/\,\-][0-7]+)*$/', $value);
     }

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -82,6 +82,7 @@ class DayOfWeekFieldTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($f->validate('FRI#5'));
         $this->assertTrue($f->validate('SAT#1'));
         $this->assertTrue($f->validate('SUN#3'));
+        $this->assertTrue($f->validate('MON#1,MON#3'));
     }
 
     /**


### PR DESCRIPTION
See https://github.com/mtdowling/cron-expression/issues/70.

This fix can, if desired at all, most certainly be done in a more elegant way using regex only (if not getting too complicated itself then), but it's at least a workaround for now to prevent the Exception.

ps @mtdowling thanks for your great work both on Guzzle and this library.