### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,8 @@ php:
   - 5.6
   - hhvm
 
-matrix:
-    allow_failures:
-        - php: hhvm
+sudo: false
 
-before_script:
-  - composer self-update
-  - composer install
+install: travis_retry composer install --no-interaction --prefer-source
 
 script: phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,8 @@ sudo: false
 install: travis_retry composer install --no-interaction --prefer-source
 
 script: phpunit --coverage-text
+
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
Let's speed things up by:
* Not self-updating composer
* Not using a dist-install that fails most of the time and then we end up retrying via source mode
* Running on travis' new container infrastructure
* Enabling fast finish so that travis will mark the whole build as green if php is done, but hhvm is still running

I've also made sure composer will be retried if we hit some kind of error and that composer is forced not to prompt for user interaction.