### PR TITLE
Implemented dynamic maxIterationCount for getRunDate()

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -34,6 +34,11 @@ class CronExpression
     private $fieldFactory;
 
     /**
+     * @var int Max iteration count when searching for next run date
+     */
+    private $maxIterationCount = 1000;
+
+    /**
      * @var array Order in which to test of cron parts
      */
     private static $order = array(self::YEAR, self::MONTH, self::DAY, self::WEEKDAY, self::HOUR, self::MINUTE);
@@ -146,6 +151,20 @@ class CronExpression
 
         $this->cronParts[$position] = $value;
 
+        return $this;
+    }
+
+    /**
+     * Set max iteration count for searching next run dates
+     *
+     * @param int $maxIterationCount Max iteration count when searching for next run date
+     *
+     * @return CronExpression
+     */
+    public function setMaxIterationCount($maxIterationCount)
+    {
+        $this->maxIterationCount = $maxIterationCount;
+        
         return $this;
     }
 
@@ -310,7 +329,7 @@ class CronExpression
         }
 
         // Set a hard limit to bail on an impossible date
-        for ($i = 0; $i < 1000; $i++) {
+        for ($i = 0; $i < $this->maxIterationCount; $i++) {
 
             foreach ($parts as $position => $part) {
                 $satisfied = false;

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -275,7 +275,13 @@ class CronExpressionTest extends \PHPUnit_Framework_TestCase
             new DateTime('2008-11-09 00:04:00'),
             new DateTime('2008-11-09 00:06:00')
         ), $cron->getMultipleRunDates(4, '2008-11-09 00:00:00', false, true));
+    }
 
+    /**
+     * @covers Cron\CronExpression::getMultipleRunDates
+     * @covers Cron\CronExpression::setMaxIterationCount
+     */
+    public function testProvidesMultipleRunDatesForTheFarFuture() {
         // Fails with the default 1000 iteration limit
         $cron = CronExpression::factory('0 0 12 1 * */2');
         $cron->setMaxIterationCount(2000);

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -275,6 +275,21 @@ class CronExpressionTest extends \PHPUnit_Framework_TestCase
             new DateTime('2008-11-09 00:04:00'),
             new DateTime('2008-11-09 00:06:00')
         ), $cron->getMultipleRunDates(4, '2008-11-09 00:00:00', false, true));
+
+        // Fails with the default 1000 iteration limit
+        $cron = CronExpression::factory('0 0 12 1 * */2');
+        $cron->setMaxIterationCount(2000);
+        $this->assertEquals(array(
+            new DateTime('2016-01-12 00:00:00'),
+            new DateTime('2018-01-12 00:00:00'),
+            new DateTime('2020-01-12 00:00:00'),
+            new DateTime('2022-01-12 00:00:00'),
+            new DateTime('2024-01-12 00:00:00'),
+            new DateTime('2026-01-12 00:00:00'),
+            new DateTime('2028-01-12 00:00:00'),
+            new DateTime('2030-01-12 00:00:00'),
+            new DateTime('2032-01-12 00:00:00'),
+        ), $cron->getMultipleRunDates(9, '2015-04-28 00:00:00', false, true));
     }
 
     /**


### PR DESCRIPTION
I have implemented a `maxIterationCount` property that is used as the limit to bail on an impossible date in `getRunDate()`.

When generating run dates that lie further in the future, the hard coded 1000 iterations aren't always enough (see Issue #66). 
To work around this, you can now set the `maxIterationCount` via the setter method `setMaxIterationCount`.