### PR TITLE
Support for non-hourly offset timezones - refs issues 55 and 76

### DIFF
--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -18,13 +18,19 @@ class HoursField extends AbstractField
         // allow us to go back or forwards and hour even
         // if DST will be changed between the hours.
         $timezone = $date->getTimezone();
+		$localMinutes = $date->format('i');
         $date->setTimezone(new \DateTimeZone('UTC'));
+		// handle timezones with non-hour-offsets	
+		$utcMinutes = $date->format('i');	
+		$minDiff = $localMinutes - $utcMinutes;
         if ($invert) {
             $date->modify('-1 hour');
-            $date->setTime($date->format('H'), 59);
+			$minutes = 59;
+            $date->setTime($date->format('H'), 59 - $minDiff);			
         } else {
             $date->modify('+1 hour');
-            $date->setTime($date->format('H'), 0);
+			$minutes = 0;
+            $date->setTime($date->format('H'), 0 - $minDiff);		
         }
         $date->setTimezone($timezone);
 

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -7,38 +7,36 @@ namespace Cron;
  */
 class HoursField extends AbstractField
 {
-    public function isSatisfiedBy(\DateTime $date, $value)
+    public function isSatisfiedBy( \DateTime $date, $value )
     {
-        return $this->isSatisfied($date->format('H'), $value);
+        return $this->isSatisfied( $date->format( 'H' ), $value );
     }
 
-    public function increment(\DateTime $date, $invert = false)
+    public function increment( \DateTime $date, $invert = false )
     {
         // Change timezone to UTC temporarily. This will
         // allow us to go back or forwards and hour even
         // if DST will be changed between the hours.
-        $timezone = $date->getTimezone();
-		$localMinutes = $date->format('i');
-        $date->setTimezone(new \DateTimeZone('UTC'));
-		// handle timezones with non-hour-offsets	
-		$utcMinutes = $date->format('i');	
-		$minDiff = $localMinutes - $utcMinutes;
+        $timezone     = $date->getTimezone();
+        $localMinutes = $date->format( 'i' );
+        $date->setTimezone( new \DateTimeZone( 'UTC' ) );
+        // handle timezones with non-hour-offsets
+        $utcMinutes = $date->format( 'i' );
+        $minDiff    = $localMinutes - $utcMinutes;
         if ($invert) {
-            $date->modify('-1 hour');
-			$minutes = 59;
-            $date->setTime($date->format('H'), 59 - $minDiff);			
+            $date->modify( '-1 hour' );
+            $date->setTime( $date->format( 'H' ), 59 - $minDiff );
         } else {
-            $date->modify('+1 hour');
-			$minutes = 0;
-            $date->setTime($date->format('H'), 0 - $minDiff);		
+            $date->modify( '+1 hour' );
+            $date->setTime( $date->format( 'H' ), 0 - $minDiff );
         }
-        $date->setTimezone($timezone);
+        $date->setTimezone( $timezone );
 
         return $this;
     }
 
-    public function validate($value)
+    public function validate( $value )
     {
-        return (bool) preg_match('/^[\*,\/\-0-9]+$/', $value);
+        return (bool)preg_match( '/^[\*,\/\-0-9]+$/', $value );
     }
 }

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -35,4 +35,23 @@ class HoursFieldTest extends \PHPUnit_Framework_TestCase
         $f->increment($d, true);
         $this->assertEquals('2011-03-15 10:59:00', $d->format('Y-m-d H:i:s'));
     }
+	
+    /**
+     * @covers Cron\HoursField::increment
+     */
+    public function testIncrementsDateWithThirtyMinuteOffsetTimezone()
+    {
+		$tz = date_default_timezone_get();
+		date_default_timezone_set('America/St_Johns');
+        $d = new DateTime('2011-03-15 11:15:00');		
+        $f = new HoursField();
+        $f->increment($d);
+        $this->assertEquals('2011-03-15 12:00:00', $d->format('Y-m-d H:i:s'));
+
+        $d->setTime(11, 15, 0);
+        $f->increment($d, true);
+        $this->assertEquals('2011-03-15 10:59:00', $d->format('Y-m-d H:i:s'));
+		date_default_timezone_set($tz);
+    }
+	
 }

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -16,10 +16,10 @@ class MonthFieldTest extends \PHPUnit_Framework_TestCase
     public function testValdatesField()
     {
         $f = new MonthField();
-        $this->assertTrue($f->validate('12'));
-        $this->assertTrue($f->validate('*'));
-        $this->assertTrue($f->validate('*/10,2,1-12'));
-        $this->assertFalse($f->validate('1.fix-regexp'));
+        $this->assertTrue( $f->validate( '12' ) );
+        $this->assertTrue( $f->validate( '*' ) );
+        $this->assertTrue( $f->validate( '*/10,2,1-12' ) );
+        $this->assertFalse( $f->validate( '1.fix-regexp' ) );
     }
 
     /**
@@ -27,15 +27,34 @@ class MonthFieldTest extends \PHPUnit_Framework_TestCase
      */
     public function testIncrementsDate()
     {
-        $d = new DateTime('2011-03-15 11:15:00');
+        $d = new DateTime( '2011-03-15 11:15:00' );
         $f = new MonthField();
-        $f->increment($d);
-        $this->assertEquals('2011-04-01 00:00:00', $d->format('Y-m-d H:i:s'));
+        $f->increment( $d );
+        $this->assertEquals( '2011-04-01 00:00:00', $d->format( 'Y-m-d H:i:s' ) );
 
-        $d = new DateTime('2011-03-15 11:15:00');
-        $f->increment($d, true);
-        $this->assertEquals('2011-02-28 23:59:00', $d->format('Y-m-d H:i:s'));
+        $d = new DateTime( '2011-03-15 11:15:00' );
+        $f->increment( $d, true );
+        $this->assertEquals( '2011-02-28 23:59:00', $d->format( 'Y-m-d H:i:s' ) );
     }
+
+    /**
+     * @covers Cron\MonthField::increment
+     */
+    public function testIncrementsDateWithThirtyMinuteTimezone()
+    {
+        $tz = date_default_timezone_get();
+        date_default_timezone_set( 'America/St_Johns' );
+        $d = new DateTime( '2011-03-31 11:59:59' );
+        $f = new MonthField();
+        $f->increment( $d );
+        $this->assertEquals( '2011-04-01 00:00:00', $d->format( 'Y-m-d H:i:s' ) );
+
+        $d = new DateTime( '2011-03-15 11:15:00' );
+        $f->increment( $d, true );
+        $this->assertEquals( '2011-02-28 23:59:00', $d->format( 'Y-m-d H:i:s' ) );
+        date_default_timezone_set( $tz );
+    }
+
 
     /**
      * @covers Cron\MonthField::increment
@@ -43,9 +62,9 @@ class MonthFieldTest extends \PHPUnit_Framework_TestCase
     public function testIncrementsYearAsNeeded()
     {
         $f = new MonthField();
-        $d = new DateTime('2011-12-15 00:00:00');
-        $f->increment($d);
-        $this->assertEquals('2012-01-01 00:00:00', $d->format('Y-m-d H:i:s'));
+        $d = new DateTime( '2011-12-15 00:00:00' );
+        $f->increment( $d );
+        $this->assertEquals( '2012-01-01 00:00:00', $d->format( 'Y-m-d H:i:s' ) );
     }
 
     /**
@@ -54,8 +73,8 @@ class MonthFieldTest extends \PHPUnit_Framework_TestCase
     public function testDecrementsYearAsNeeded()
     {
         $f = new MonthField();
-        $d = new DateTime('2011-01-15 00:00:00');
-        $f->increment($d, true);
-        $this->assertEquals('2010-12-31 23:59:00', $d->format('Y-m-d H:i:s'));
+        $d = new DateTime( '2011-01-15 00:00:00' );
+        $f->increment( $d, true );
+        $this->assertEquals( '2010-12-31 23:59:00', $d->format( 'Y-m-d H:i:s' ) );
     }
 }


### PR DESCRIPTION
Great package!

Our project has a requirement to support non-hourly offset timezones ('America/St_Johns' for example) and a colleague of mine has created a fork which resolves the "Impossible CronExpression" issue when using these timezones.

This PR should help resolve:
https://github.com/mtdowling/cron-expression/issues/55
https://github.com/mtdowling/cron-expression/issues/76

Thanks,
Alan