### PR TITLE
Improvement: accept DateTimeImmutable where appropriate on public-facing APIs

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -258,6 +258,11 @@ class CronExpression
             $currentDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
             $currentDate = $currentDate->format('Y-m-d H:i');
             $currentTime = strtotime($currentDate);
+        } elseif ($currentTime instanceof \DateTimeImmutable) {
+            $currentDate = \DateTime::createFromFormat('U', $currentTime->format('U'));
+            $currentDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+            $currentDate = $currentDate->format('Y-m-d H:i');
+            $currentTime = strtotime($currentDate);
         } else {
             $currentTime = new \DateTime($currentTime);
             $currentTime->setTime($currentTime->format('H'), $currentTime->format('i'), 0);
@@ -288,6 +293,9 @@ class CronExpression
     {
         if ($currentTime instanceof \DateTime) {
             $currentDate = clone $currentTime;
+        } elseif ($currentTime instanceof \DateTimeImmutable) {
+            $currentDate = \DateTime::createFromFormat('U', $currentTime->format('U'));
+            $currentDate->setTimezone($currentTime->getTimezone());
         } else {
             $currentDate = new \DateTime($currentTime ?: 'now');
             $currentDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));


### PR DESCRIPTION
A couple of public-facing APIs are prepared to accept `DateTime` instances, but not `DateTimeImmutable`. This PR updates the code so that it also accepts `DateTimeImmutable`.

I tried to make the minimum possible volume of modifications, which means that the result doesn't read as nicely as fresh code written with PHP 5.5 in mind. I'm willing to rewrite more if that is required.