### PR TITLE
getMultipleRunDates of a "once cron expression"

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -202,7 +202,11 @@ class CronExpression
     {
         $matches = array();
         for ($i = 0; $i < max(0, $total); $i++) {
-            $matches[] = $this->getRunDate($currentTime, $i, $invert, $allowCurrentDate);
+            try {
+                $matches[] = $this->getRunDate($currentTime, $i, $invert, $allowCurrentDate);
+            } catch (\RuntimeException $e) {
+                break;
+            }
         }
 
         return $matches;


### PR DESCRIPTION
If you try to get more than one run date for a "once cron expression" (i.e. 46 20 27 10 * 2015), getRunDate will throw an exception because it´s imposible to get a second run date, and we lost the date of the first (an unique) run. I think this can be controlled by catching the exception in getMultipleRunDates and breaking the getRunDate loop to return any run dates we have collected before the expression becomes imposible.