### PR TITLE
Fix hanging test on PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 sudo: false

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -36,7 +36,10 @@ class DayOfWeekField extends AbstractField
             $tdate = clone $date;
             $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
             while ($tdate->format('w') != $weekday) {
-                $tdate->setDate($currentYear, $currentMonth, --$lastDayOfMonth);
+                $tdateClone = new \DateTime();
+                $tdate = $tdateClone
+                    ->setTimezone($tdate->getTimezone())
+                    ->setDate($currentYear, $currentMonth, --$lastDayOfMonth);
             }
 
             return $date->format('j') == $lastDayOfMonth;


### PR DESCRIPTION
By cloning the `DateTime` instance I was able to get all the tests to run on PHP 7. Somehow the `setDate` method did not change the value of `$tdate`.

This is not the most beautiful solution but it works. Maybe someone else has an idea why exactly `setDate` does not change the value and has a better fix for it.