### PR TITLE
Implement Jenkins style hash entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "homepage": "https://github.com/mtdowling"
     }],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "ruafozy/mersenne-twister": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|~5.0"

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
+use mersenne_twister\twister;
 use RuntimeException;
 
 /**
@@ -311,9 +312,20 @@ class CronExpression
     }
 
     protected function getHashValue($position) {
+        $twister = new twister();
+        $twister->init_with_string(sha1($position . $this->getHashData()));
         $max = $this->fieldFactory->getField($position)->maxHashValue();
-        return round(rand(0, $max));
+        return $twister->rangeint(0, $max);
     }
+
+    /**
+     * @return string
+     */
+    public function getHashData() {
+        return $this->hashData;
+    }
+
+
 
     /**
      * Get the next or previous run date of the expression relative to a date

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -45,6 +45,8 @@ class CronExpression
      */
     private $maxIterationCount = 1000;
 
+    private $hashData = '';
+
     /**
      * @var array Order in which to test of cron parts
      */
@@ -66,7 +68,7 @@ class CronExpression
      *
      * @return CronExpression
      */
-    public static function factory($expression, FieldFactory $fieldFactory = null)
+    public static function factory($expression, FieldFactory $fieldFactory = null, $hashData = '')
     {
         $mappings = array(
             '@yearly' => '0 0 1 1 *',
@@ -81,7 +83,7 @@ class CronExpression
             $expression = $mappings[$expression];
         }
 
-        return new static($expression, $fieldFactory ?: new FieldFactory());
+        return new static($expression, $fieldFactory ?: new FieldFactory(), $hashData);
     }
 
     /**
@@ -109,9 +111,10 @@ class CronExpression
      * @param string       $expression   CRON expression (e.g. '8 * * * *')
      * @param FieldFactory $fieldFactory Factory to create cron fields
      */
-    public function __construct($expression, FieldFactory $fieldFactory)
+    public function __construct($expression, FieldFactory $fieldFactory, $hashData)
     {
         $this->fieldFactory = $fieldFactory;
+        $this->hashData = $hashData;
         $this->setExpression($expression);
     }
 
@@ -307,6 +310,11 @@ class CronExpression
         }
     }
 
+    protected function getHashValue($position) {
+        $max = $this->fieldFactory->getField($position)->maxHashValue();
+        return round(rand(0, $max));
+    }
+
     /**
      * Get the next or previous run date of the expression relative to a date
      *
@@ -342,6 +350,9 @@ class CronExpression
             $part = $this->getExpression($position);
             if (null === $part || '*' === $part) {
                 continue;
+            }
+            if (strpos($part, 'H') !== false) {
+                $part = preg_replace('/H/', $this->getHashValue($position), $part);
             }
             $parts[$position] = $part;
             $fields[$position] = $this->fieldFactory->getField($position);

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -85,6 +85,14 @@ class DayOfMonthField extends AbstractField
         return $this->isSatisfied($date->format('d'), $value);
     }
 
+    public function minHashValue() {
+        return 1;
+    }
+
+    public function maxHashValue() {
+        return 31;
+    }
+
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -104,6 +104,14 @@ class DayOfWeekField extends AbstractField
         return $this->isSatisfied($fieldValue, $value);
     }
 
+    public function minHashValue() {
+        return 0;
+    }
+
+    public function maxHashValue() {
+        return 6;
+    }
+
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -15,8 +15,12 @@ class HoursField extends AbstractField
         return $this->isSatisfied($date->format('H'), $value);
     }
 
+    public function minHashValue() {
+        return 0;
+    }
+
     public function maxHashValue() {
-        return 59;
+        return 23;
     }
 
     public function increment(DateTime $date, $invert = false, $parts = null)

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -15,6 +15,10 @@ class HoursField extends AbstractField
         return $this->isSatisfied($date->format('H'), $value);
     }
 
+    public function maxHashValue() {
+        return 59;
+    }
+
     public function increment(DateTime $date, $invert = false, $parts = null)
     {
         // Change timezone to UTC temporarily. This will
@@ -66,6 +70,6 @@ class HoursField extends AbstractField
 
     public function validate($value)
     {
-        return (bool) preg_match('/^[\*,\/\-0-9]+$/', $value);
+        return (bool) preg_match('/^[\*,\/\-0-9H]+$/', $value);
     }
 }

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -15,6 +15,14 @@ class MinutesField extends AbstractField
         return $this->isSatisfied($date->format('i'), $value);
     }
 
+    public function minHashValue() {
+        return 0;
+    }
+
+    public function maxHashValue() {
+        return 59;
+    }
+
     public function increment(DateTime $date, $invert = false, $parts = null)
     {
         if (is_null($parts)) {
@@ -57,6 +65,6 @@ class MinutesField extends AbstractField
 
     public function validate($value)
     {
-        return (bool) preg_match('/^[\*,\/\-0-9]+$/', $value);
+        return (bool) preg_match('/^[\*,\/\-0-9H]+$/', $value);
     }
 }

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -24,6 +24,14 @@ class MonthField extends AbstractField
         return $this->isSatisfied($date->format('m'), $value);
     }
 
+    public function minHashValue() {
+        return 1;
+    }
+
+    public function maxHashValue() {
+        return 12;
+    }
+
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -414,8 +414,12 @@ class CronExpressionTest extends PHPUnit_Framework_TestCase
 
     public function testHashWorks()
     {
-        $cron = CronExpression::factory('0 H * * 0');
+        $cron = CronExpression::factory('H H * * *', null, 'data');
         $nextRun = $cron->getNextRunDate("2008-11-09 08:00:00");
-        $this->assertEquals($nextRun, new DateTime("2008-11-16 00:00:00"));
+        $this->assertEquals(new DateTime("2008-11-09 09:29:00"), $nextRun);
+
+        $cron = CronExpression::factory('H H * * *', null, 'data2');
+        $nextRun = $cron->getNextRunDate("2008-11-09 08:00:00");
+        $this->assertEquals(new DateTime("2008-11-10 06:56:00"), $nextRun);
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -411,4 +411,11 @@ class CronExpressionTest extends PHPUnit_Framework_TestCase
         // Valid
         $this->assertTrue(CronExpression::isValidExpression('* * * * 1'));
     }
+
+    public function testHashWorks()
+    {
+        $cron = CronExpression::factory('0 H * * 0');
+        $nextRun = $cron->getNextRunDate("2008-11-09 08:00:00");
+        $this->assertEquals($nextRun, new DateTime("2008-11-16 00:00:00"));
+    }
 }


### PR DESCRIPTION
Some proof of concept quality code to implement the feature described in #121.

This probably needs to get refactored out into an additional interface that the fields can implement that will then pass the configured twister to them when calling `isSatisfiedBy` in much in the same way that the `DayOfWeekField` class currently implements changing the day of the week literals into a numbers at the top of that method.