### PR TITLE
Add (unofficial) support for 'last workday of month'

### DIFF
--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -70,6 +70,21 @@ class DayOfMonthField extends AbstractField
             return $fieldValue == $date->format('t');
         }
 
+        // Find out if this is the last workday (monday-friday) of the month
+        if ( $value == 'D' ) {
+            $tdate = clone $date;
+            $tdate->setDate($date->format('Y'), $date->format('m'), $date->format('t'));
+
+            $lastWorkDay = $tdate->format('w');
+            if ( $lastWorkDay == 0 ) {
+              $tdate->modify('-2 days');
+            } else if ( $lastWorkDay == 6 ) {
+              $tdate->modify('-1 day');
+            }
+
+            return $fieldValue == $tdate->format('d');
+        }
+
         // Check to see if this is the nearest weekday to a particular value
         if (strpos($value, 'W')) {
             // Parse the target day
@@ -100,6 +115,6 @@ class DayOfMonthField extends AbstractField
 
     public function validate($value)
     {
-        return (bool) preg_match('/^[\*,\/\-\?LW0-9A-Za-z]+$/', $value);
+        return (bool) preg_match('/^[\*,\/\-\?LWD0-9A-Za-z]+$/', $value);
     }
 }

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -22,6 +22,7 @@ class DayOfMonthFieldTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($f->validate('*/3,1,1-12'));
         $this->assertTrue($f->validate('5W,L'));
         $this->assertFalse($f->validate('1.'));
+        $this->assertTrue($f->validate('D'));
     }
 
     /**
@@ -31,6 +32,8 @@ class DayOfMonthFieldTest extends PHPUnit_Framework_TestCase
     {
         $f = new DayOfMonthField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2016-01-29'), 'D'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2016-12-30'), 'D'));
     }
 
     /**


### PR DESCRIPTION
Added support for 'D' in month field that matches up against the last workday of a month.

Ex, for January 2016: The 29th. I know this is not in the crontab spec, but this came up during a project at work and I found it handy.
