### PR TITLE
Handle 0-sized steps somewhat more sanely

### DIFF
--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -76,8 +76,13 @@ abstract class AbstractField implements FieldInterface
     public function isInIncrementsOfRanges($dateValue, $value)
     {
         $parts = array_map('trim', explode('/', $value, 2));
-        $stepSize = isset($parts[1]) ? $parts[1] : 0;
-        if (($parts[0] == '*' || $parts[0] === '0') && 0 !== $stepSize) {
+        $stepSize = isset($parts[1]) ? (int) $parts[1] : 0;
+
+        if ($stepSize === 0) {
+            return false;
+        }
+
+        if (($parts[0] == '*' || $parts[0] === '0')) {
             return (int) $dateValue % $stepSize == 0;
         }
 

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -62,6 +62,8 @@ class AbstractFieldTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($f->isInIncrementsOfRanges(3, '2-59'));
         $this->assertFalse($f->isInIncrementsOfRanges(3, '2'));
         $this->assertFalse($f->isInIncrementsOfRanges(3, '*'));
+        $this->assertFalse($f->isInIncrementsOfRanges(0, '*/0'));
+        $this->assertFalse($f->isInIncrementsOfRanges(1, '*/0'));
 
         $this->assertTrue($f->isInIncrementsOfRanges(4, '4/10'));
         $this->assertTrue($f->isInIncrementsOfRanges(14, '4/10'));


### PR DESCRIPTION
Zero-sized steps will now fail instead of being mistakenly interpreted as ranges.

Fixes #124 
