### PR TITLE
Fixed incorrect version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~5.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
5.7.0 was the first version to ship with the BC layer (in it's current form that is), so it's incorrect to allow the installation of older versions.