### PR TITLE
Fix DayOfMonthField validation for just 'L'

### DIFF
--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -108,9 +108,15 @@ class DayOfMonthField extends AbstractField
     {
         $basicChecks = parent::validate($value);
 
+        // Validate that a list don't have W or L
+        if (strpos($value, ',') !== false && (strpos($value, 'W') !== false || strpos($value, 'L') !== false)) {
+            return false;
+        }
+
         if (!$basicChecks) {
-            if (preg_match('/^(.*)L$/', $value, $matches)) {
-                return $this->validate($matches[1]);
+
+            if ($value === 'L') {
+                return true;
             }
 
             if (preg_match('/^(.*)W$/', $value, $matches)) {

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -19,6 +19,8 @@ class DayOfMonthFieldTest extends TestCase
         $f = new DayOfMonthField();
         $this->assertTrue($f->validate('1'));
         $this->assertTrue($f->validate('*'));
+        $this->assertTrue($f->validate('L'));
+        $this->assertTrue($f->validate('5W'));
         $this->assertFalse($f->validate('5W,L'));
         $this->assertFalse($f->validate('1.'));
     }


### PR DESCRIPTION
Right now we can't use 'L' or 'W' for the DayOfMonthField. We get the following error:

Fatal error: Uncaught InvalidArgumentException: Invalid CRON field value L at position 2 in vendor/mtdowling/cron-expression/src/Cron/CronExpression.php on line 154

This pull request solve this problem

NOTE: I redo the pull request to clean the commits
Reference to: https://github.com/mtdowling/cron-expression/pull/157