### PR TITLE
Update composer.json to suggest new fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,8 @@
         "psr-4": {
             "Tests\\": "tests/Cron/"
         }
+    },
+    "suggest": {
+        "dragonmantank/cron-expression": "Cron Expression 2 has moved to a new package name. The package you have installed, mtdowling/cron-expression:1.2, is no longer maintained."
     }
 }


### PR DESCRIPTION
Since mtdowling/cron-expression is no longer maintained, suggest installing dragonmantank/cron-expression.

It might be helpful to users to mark the package on packagist as abandoned as well, similar to what guzzle/ has done.

Ping @dragonmantank @mtdowling 