### PR TITLE
Update CronExpression.php

### DIFF
--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -388,7 +388,10 @@ class CronExpression
 
             // Skip this match if needed
             if ((!$allowCurrentDate && $nextRun == $currentDate) || --$nth > -1) {
-                $this->fieldFactory->getField(0)->increment($nextRun, $invert, isset($parts[0]) ? $parts[0] : null);
+                //Fix bug #170 - getMultipleRunDates error
+                //$this->fieldFactory->getField(0)->increment($nextRun, $invert, isset($parts[0]) ? $parts[0] : null);
+                
+                $field->increment($nextRun, $invert, $part);
                 continue;
             }
 


### PR DESCRIPTION
It seams to consider always "minutes" instead of crontab expression if no time is set when increment or decrement