### PR TITLE
Add static isValid function to CronExpression

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,11 @@
 * text=auto
 
-.gitattributes export-ignore
-.gitignore export-ignore
-.php_cs export-ignore
-.styleci.yml export-ignore
-.travis.yml export-ignore
-phpunit.xml.dist export-ignore
+/.github export-ignore
+/tests export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs export-ignore
+/.styleci.yml export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 /.php_cs export-ignore
 /.styleci.yml export-ignore
 /.travis.yml export-ignore
+/phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 /.travis.yml export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
+/phpstan.neon export-ignore

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [dragonmantank]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: Tests
+
+jobs:
+  phpstan:
+    name: PHPStan - PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: PHPStan
+        uses: docker://oskarstark/phpstan-ga
+        with:
+          args: analyse  --level=max src tests
+
+  phpunit:
+    name: PHPUnit - PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: PHPUnit
+        uses: php-actions/phpunit@v9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
-    continue-on-error: ${{ matrix.php == '8.0' }}
+        php: [7.2, 7.3, 7.4, 8.0, 8.1]
 
     steps:
       - name: "Checkout"
@@ -35,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,17 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          args: analyse --level=max src
+          php-version: ${{ matrix.php }}
+          extensions: json, mbstring
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Start Static Analyze
+        run: composer phpstan -n
 
   phpunit:
     name: PHPUnit - PHP ${{ matrix.php }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.1, 7.2, 7.3, 7.4, 8.0]
+    continue-on-error: ${{ matrix.php == '8.0' }}
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0]
     continue-on-error: ${{ matrix.php == '8.0' }}
 
     steps:
@@ -26,7 +26,7 @@ jobs:
       - name: PHPStan
         uses: docker://oskarstark/phpstan-ga
         with:
-          args: analyse  --level=max src tests
+          args: analyse --level=max src
 
   phpunit:
     name: PHPUnit - PHP ${{ matrix.php }}
@@ -35,11 +35,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0]
 
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v2
 
-      - name: PHPUnit
-        uses: php-actions/phpunit@v9
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, mbstring
+          coverage: pcov
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Get Composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Analyze & test
+        run: composer test -- -v --coverage-clover=coverage.xml

--- a/.php_cs
+++ b/.php_cs
@@ -1,15 +1,82 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
 
-$fixers = array(
-    '-psr0',
-    'long_array_syntax',
-);
+$config = PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'declare_strict_types' => true,
+        'native_function_invocation' => [
+            'include' => ['@compiler_optimized'],
+            'scope' => 'namespaced',
+        ],
+        'phpdoc_align' => [
+            'align' => 'left',
+        ],
+        'blank_line_before_statement' => true,
+        'align_multiline_comment' => false,
+        'concat_space' => [
+            'spacing' => 'one',
+        ],
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
+        'combine_consecutive_issets' => true,
+        'combine_consecutive_unsets' => true,
+        'array_indentation' => true,
+        'no_extra_blank_lines' => [
+            'break',
+            'case',
+            'continue',
+            'curly_brace_block',
+            'default',
+            'extra',
+            'parenthesis_brace_block',
+            'return',
+            'square_brace_block',
+            'switch',
+            'throw',
+            'use',
+            'useTrait',
+            'use_trait',
+        ],
+        'compact_nullable_typehint' => true,
+        'escape_implicit_backslashes' => true,
+        'explicit_indirect_variable' => true,
+        'explicit_string_variable' => true,
+        'final_internal_class' => true,
+        'fully_qualified_strict_types' => true,
+        'function_to_constant' => [
+            'functions' => [
+                'get_class',
+                'get_called_class',
+                'php_sapi_name',
+                'phpversion',
+                'pi',
+            ],
+        ],
+        'list_syntax' => [
+            'syntax' => 'short',
+        ],
+        'logical_operators' => true,
+        'no_alternative_syntax' => true,
+        'no_null_property_initialization' => true,
+        'no_short_echo_tag' => true,
+        'no_superfluous_elseif' => false,
+        'no_unreachable_default_argument_value' => true,
+        'no_unset_on_property' => false,
+        'no_useless_else' => false,
+        'ordered_imports' => true,
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_order' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_types_order' => true,
+        'return_assignment' => true,
+        'string_line_ending' => true,
+        'strict_param' => true,
+        'strict_comparison' => true,
+    ])
+    ->setFinder($finder);
 
-return Symfony\CS\Config\Config::create()
-    ->finder($finder)
-    ->fixers($fixers)
-    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-    ->setUsingCache(true);
+return $config;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,5 @@
 preset: psr2
 
 enabled:
-  - long_array_syntax
+  - short_array_syntax
   - method_separation

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ sudo: false
 
 matrix:
   include:
-    - php: 7.0
-    - php: 7.0
-      env: dependencies=lowest
-    - php: 7.1
-    - php: 7.1
-      env: dependencies=lowest
     - php: 7.2
     - php: 7.2
       env: dependencies=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+dist: bionic
 
 matrix:
   include:
@@ -13,12 +13,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: dependencies=lowest
-    - php: nightly
-    - php: nightly
+    - php: 7.4
+    - php: 7.4
       env: dependencies=lowest
-  allow_failures:
-    - php: nightly
-  fast_finish: true
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
     - php: 7.4
     - php: 7.4
       env: dependencies=lowest
+    - php: nightly
+      install: travis_retry composer install --no-interaction --prefer-dist --ignore-platform-reqs
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: false
 
 matrix:
   include:
+    - php: 7.1
+    - php: 7.1
+      env: dependencies=lowest
     - php: 7.2
     - php: 7.2
       env: dependencies=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,6 @@ install:
           travis_retry composer install --no-interaction --prefer-dist
         fi
 
-script: vendor/bin/phpunit --coverage-text
+script:
+  - vendor/bin/phpunit --coverage-text
+  - composer phpstan

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,14 @@ matrix:
     - php: 7.2
     - php: 7.2
       env: dependencies=lowest
-    - php: nighly
-    - php: nighly
+    - php: 7.3
+    - php: 7.3
+      env: dependencies=lowest
+    - php: nightly
+    - php: nightly
       env: dependencies=lowest
   allow_failures:
-    - php: nighly
+    - php: nightly
   fast_finish: true
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,31 @@
 language: php
 
-php:
-  - 7.0
-  - 7.1
-  - hhvm
-
 sudo: false
 
-install: travis_retry composer install --no-interaction --prefer-dist
-
-script: phpunit --coverage-text
-
 matrix:
+  include:
+    - php: 7.0
+    - php: 7.0
+      env: dependencies=lowest
+    - php: 7.1
+    - php: 7.1
+      env: dependencies=lowest
+    - php: 7.2
+    - php: 7.2
+      env: dependencies=lowest
+    - php: nighly
+    - php: nighly
+      env: dependencies=lowest
   allow_failures:
-    - php: hhvm
+    - php: nighly
   fast_finish: true
+
+install:
+    - |
+        if [[ "$dependencies" = "lowest" ]]; then
+          travis_retry composer update --no-interaction --prefer-lowest --prefer-stable -n
+        else
+          travis_retry composer install --no-interaction --prefer-dist
+        fi
+
+script: vendor/bin/phpunit --coverage-text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.3.0] - 2019-03-30
+### Added
+- Added support for DateTimeImmutable via DateTimeInterface
+- Added support for PHP 7.3
+- Started listing projects that use the library
+### Changed
+- Errors should now report a human readable position in the cron expression, instead of starting at 0
+### Fixed
+- N/A
+
 ## [2.2.0] - 2018-06-05
 ### Added
 - Added support for steps larger than field ranges (#6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [3.3.3] - 2024-08-10
+
+### Added
+- N/A
+
+### Changed
+- N/A
+
+### Fixed
+- Added fixes for making sure `?` is not passed for both DOM and DOW (#148, thank you https://github.com/LeoVie)
+- Fixed bug in Next Execution Time by sorting minutes properly (#160, thank you https://github.com/imyip)
+
 ## [3.3.2] - 2022-09-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [3.1.0] - 2020-11-24
+
+### Added
+- Added `CronExpression::getParts()` method to get parts of the expression as an array (#83)
+
+### Changed
+- Changed to Interfaces for some type hints (#97, #86)
+- Dropped minimum PHP version to 7.2
+- Few syntax changes for phpstan compatibility (#93)
+
+### Fixed
+- N/A
+
+### Deprecated
+- Deprecated `CronExpression::factory` in favor of the constructor (#56)
+- Deprecated `CronExpression::YEAR` as a formality, the functionality is already removed (#87)
+
 ## [3.0.1] - 2020-10-12
 ### Added
 - Added support for PHP 8 (#92)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [2.2.0] - 2018-06-05
+### Added
+- Added support for steps larger than field ranges (#6)
+## Changed
+- N/A
+### Fixed
+- Fixed validation for numbers with leading 0s (#12)
+
 ## [2.1.0] - 2018-04-06
 ### Added
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [3.3.2] - 2022-09-19
+
+### Added
+- N/A
+
+### Changed
+- Skip some daylight savings time tests for PHP 8.1 daylight savings time weirdness (#146)
+
+### Fixed
+- Changed string interpolations to work better with PHP 8.2 (#142)
+
 ## [3.3.1] - 2022-01-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.1.0] - 2018-04-06
+### Added
+- N/A
+### Changed
+- Upgraded to PHPUnit 6 (#2)
+### Fixed
+- Refactored timezones to deal with some inconsistent behavior (#3)
+- Allow ranges and lists in same expression (#5)
+- Fixed regression where literals were not converted to their numerical counterpart (#)
+
 ## [2.0.0] - 2017-10-12
 ### Added
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [3.0.1] - 2020-10-12
+### Added
+- Added support for PHP 8 (#92)
+### Changed
+- N/A
+### Fixed
+- N/A
+
 ## [3.0.0] - 2020-03-25
 
 **MAJOR CHANGE** - In previous versions of this library, setting both a "Day of Month" and a "Day of Week" would be interpreted as an `AND` statement, not an `OR` statement. For example:
@@ -24,6 +32,14 @@ would evaluate to "Run 30 minutes after the 0 hour when the Day Of Month is 1 AN
 - Fixed bug where single number ranges were allowed (ex: `1/10`)
 - Fixed nullable FieldFactory in CronExpression where no factory could be supplied
 - Fixed issue where logic for dropping seconds to 0 could lead to a timezone change
+
+## [2.3.1] - 2020-10-12
+### Added
+- Added support for PHP 8 (#92)
+### Changed
+- N/A
+### Fixed
+- N/A
 
 ## [2.3.0] - 2019-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [3.2.4] - 2022-01-12
+
+### Added
+- N/A
+
+### Changed
+- Changed how Day of Week increment/decrement to help with DST changes (#131)
+
+### Fixed
+- N/A
+
 ## [3.2.3] - 2022-01-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [3.3.1] - 2022-01-18
+
+### Added
+- N/A
+
+### Changed
+- N/A
+
+### Fixed
+- Fixed issue when timezones had no transition, which can occur over very short timespans (#134)
+
 ## [3.3.0] - 2022-01-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
-## [Unreleased]
+## [2.0.0] - 2017-10-12
 ### Added
+- N/A
 
 ### Changed
 - Dropped support for PHP 5.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [3.3.0] - 2022-01-13
+
+### Added
+- Added ability to register your own expression aliases (#132)
+
+### Changed
+- Changed how Day of Week and Day of Month resolve when one or the other is `*` or `?`
+
+### Fixed
+- PHPStan should no longer error out
+
 ## [3.2.4] - 2022-01-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [3.2.0] - 2022-01-04
+
+### Added
+- Added alias for `@midnight` (#117)
+
+### Changed
+- Improved testing for instance of field in tests (#105)
+- Optimization for determining multiple run dates (#75)
+- `CronExpression` properties changed from private to protected (#106)
+
+### Fixed
+- N/A
+
 ## [3.1.0] - 2020-11-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [3.2.1] - 2022-01-04
+
+### Added
+- N/A
+
+### Changed
+- Added PHP 8.1 to testing (#125)
+
+### Fixed
+- Allow better mixture of ranges, steps, and lists (#122)
+- Fixed return order when multiple dates are requested and inverted (#121)
+- Better handling over DST (#115)
+- Fixed PHPStan tests (#130)
+
 ## [3.2.0] - 2022-01-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [3.2.3] - 2022-01-05
+
+### Added
+- N/A
+
+### Changed
+- Changed how minutes and hours increment/decrement to help with DST changes (#131)
+
+### Fixed
+- N/A
+
 ## [3.2.2] - 2022-01-05
 
 ### Added
@@ -11,6 +22,7 @@
 ### Fixed
 - Fixed issue with small ranges and large steps that caused an error with `range()` (#88)
 - Fixed issue where wraparound logic incorrectly considered high bound on range (#89)
+
 ## [3.2.1] - 2022-01-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
-## [2.4.0] - 2019-11-14
+## [3.0.0] - 2020-03-25
+
+**MAJOR CHANGE** - In previous versions of this library, setting both a "Day of Month" and a "Day of Week" would be interpreted as an `AND` statement, not an `OR` statement. For example:
+
+`30 0 1 * 1`
+
+would evaluate to "Run 30 minutes after the 0 hour when the Day Of Month is 1 AND a Monday" instead of "Run 30 minutes after the 0 hour on Day Of Month 1 OR a Monday", where the latter is more inline with most cron systems. This means that if your cron expression has both of these fields set, you may see your expression fire more often starting with v3.0.0. 
+
 ### Added
 - Additional docblocks for IDE and documentation
 - Added phpstan as a development dependency
@@ -10,6 +17,7 @@
 - Errors with fields now report a more human-understandable error and are 1-based instead of 0-based
 - Better support for `\DateTimeImmutable` across the library by typehinting for `\DateTimeInterface` now
 - Literals should now be less case-sensative across the board
+- Changed logic for when both a Day of Week and a Day of Month are supplied to now be an OR statement, not an AND
 ### Fixed
 - Fixed infinite loop when determining last day of week from literals
 - Fixed bug where single number ranges were allowed (ex: `1/10`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [3.2.2] - 2022-01-05
+
+### Added
+- N/A
+
+### Changed
+- Marked some methods `@internal` (#124)
+
+### Fixed
+- Fixed issue with small ranges and large steps that caused an error with `range()` (#88)
+- Fixed issue where wraparound logic incorrectly considered high bound on range (#89)
 ## [3.2.1] - 2022-01-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ would evaluate to "Run 30 minutes after the 0 hour when the Day Of Month is 1 AN
 ### Added
 - Additional docblocks for IDE and documentation
 - Added phpstan as a development dependency
+- Added a `Cron\FieldFactoryInterface` to make migrations easier (#38)
 ### Changed
 - Changed some DI testing during TravisCI runs
 - `\Cron\CronExpression::determineTimezone()` now checks for `\DateTimeInterface` instead of just `\DateTime`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [2.4.0] - 2019-11-14
+### Added
+- Additional docblocks for IDE and documentation
+- Added phpstan as a development dependency
+### Changed
+- Changed some DI testing during TravisCI runs
+- `\Cron\CronExpression::determineTimezone()` now checks for `\DateTimeInterface` instead of just `\DateTime`
+- Errors with fields now report a more human-understandable error and are 1-based instead of 0-based
+- Better support for `\DateTimeImmutable` across the library by typehinting for `\DateTimeInterface` now
+- Literals should now be less case-sensative across the board
+### Fixed
+- Fixed infinite loop when determining last day of week from literals
+- Fixed bug where single number ranges were allowed (ex: `1/10`)
+- Fixed nullable FieldFactory in CronExpression where no factory could be supplied
+- Fixed issue where logic for dropping seconds to 0 could lead to a timezone change
+
 ## [2.3.0] - 2019-03-30
 ### Added
 - Added support for DateTimeImmutable via DateTimeInterface

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011 Michael Dowling <mtdowling@gmail.com> and contributors
+Copyright (c) 2011 Michael Dowling <mtdowling@gmail.com>, 2016 Chris Tankersley <chris@ctankersley.com>, and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This library also supports a few macros:
 Requirements
 ============
 
-- PHP 7.1+
+- PHP 7.2+
 - PHPUnit is required to run the unit tests
 - Composer is required to run the unit tests
 

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ Projects that Use cron-expression
 =================================
 * Part of the [Laravel Framework](https://github.com/laravel/framework/)
 * Available as a [Symfony Bundle - setono/cron-expression-bundle](https://github.com/Setono/CronExpressionBundle)
-* Framework agnostic, PHP-based job scheduler - [Crunz](https://github.com/lavary/crunz)
+* Framework agnostic, PHP-based job scheduler - [Crunz](https://github.com/crunzphp/crunz)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This library also supports a few macros:
 * `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - `0 0 1 1 *`
 * `@monthly` - Run once a month, midnight, first of month - `0 0 1 * *`
 * `@weekly` - Run once a week, midnight on Sun - `0 0 * * 0`
-* `@daily` - Run once a day, midnight - `0 0 * * *`
+* `@daily`, `@midnight` - Run once a day, midnight - `0 0 * * *`
 * `@hourly` - Run once an hour, first minute - `0 * * * *`
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -32,21 +32,21 @@ Usage
 require_once '/vendor/autoload.php';
 
 // Works with predefined scheduling definitions
-$cron = Cron\CronExpression::factory('@daily');
+$cron = new Cron\CronExpression('@daily');
 $cron->isDue();
 echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
 echo $cron->getPreviousRunDate()->format('Y-m-d H:i:s');
 
 // Works with complex expressions
-$cron = Cron\CronExpression::factory('3-59/15 6-12 */15 1 2-5');
+$cron = new Cron\CronExpression('3-59/15 6-12 */15 1 2-5');
 echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
 
 // Calculate a run date two iterations into the future
-$cron = Cron\CronExpression::factory('@daily');
+$cron = new Cron\CronExpression('@daily');
 echo $cron->getNextRunDate(null, 2)->format('Y-m-d H:i:s');
 
 // Calculate a run date relative to a specific time
-$cron = Cron\CronExpression::factory('@monthly');
+$cron = new Cron\CronExpression('@monthly');
 echo $cron->getNextRunDate('2010-01-12 00:00:00')->format('Y-m-d H:i:s');
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
 echo $cron->getPreviousRunDate()->format('Y-m-d H:i:s');
 
 // Works with complex expressions
-$cron = Cron\CronExpression::factory('3-59/15 2,6-12 */15 1 2-5');
+$cron = Cron\CronExpression::factory('3-59/15 6-12 */15 1 2-5');
 echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
 
 // Calculate a run date two iterations into the future

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 PHP Cron Expression Parser
 ==========================
 
-[![Latest Stable Version](https://poser.pugx.org/mtdowling/cron-expression/v/stable.png)](https://packagist.org/packages/mtdowling/cron-expression) [![Total Downloads](https://poser.pugx.org/mtdowling/cron-expression/downloads.png)](https://packagist.org/packages/mtdowling/cron-expression) [![Build Status](https://secure.travis-ci.org/mtdowling/cron-expression.png)](http://travis-ci.org/mtdowling/cron-expression)
-
-**NOTE** This fork has been deprecated and development moved to [https://github.com/dragonmantank/cron-expression](https://github.com/dragonmantank/cron-expression). More information can be found in the blog post [here](http://ctankersley.com/2017/10/12/cron-expression-update/). tl;dr - v2.0.0 is a major breaking change, and @dragonmantank can better take care of the project in a separate fork. 
+[![Latest Stable Version](https://poser.pugx.org/dragonmantank/cron-expression/v/stable.png)](https://packagist.org/packages/dragonmantank/cron-expression) [![Total Downloads](https://poser.pugx.org/dragonmantank/cron-expression/downloads.png)](https://packagist.org/packages/dragonmantank/cron-expression) [![Build Status](https://secure.travis-ci.org/dragonmantank/cron-expression.png)](http://travis-ci.org/dragonmantank/cron-expression)
 
 The PHP cron expression parser can parse a CRON expression, determine if it is
 due to run, calculate the next run date of the expression, and calculate the previous
@@ -15,13 +13,15 @@ lists (e.g. 1,2,3), W to find the nearest weekday for a given day of the month, 
 find the last day of the month, L to find the last given weekday of a month, and hash
 (#) to find the nth weekday of a given month.
 
+More information about this fork can be found in the blog post [here](http://ctankersley.com/2017/10/12/cron-expression-update/). tl;dr - v2.0.0 is a major breaking change, and @dragonmantank can better take care of the project in a separate fork.
+
 Installing
 ==========
 
 Add the dependency to your project:
 
 ```bash
-composer require mtdowling/cron-expression
+composer require dragonmantank/cron-expression
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ Requirements
 - PHP 7.0+
 - PHPUnit is required to run the unit tests
 - Composer is required to run the unit tests
+
+Projects that Use cron-expression
+=================================
+* Part of the [Laravel Framework](https://github.com/laravel/framework/)
+* Available as a [Symfony Bundle - setono/cron-expression-bundle](https://github.com/Setono/CronExpressionBundle)

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ A CRON expression is a string representing the schedule for a particular command
 
 This library also supports a few macros:
 
-* `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
-* `@monthly` - Run once a month, midnight, first of month - 0 0 1 * *
-* `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
-* `@daily` - Run once a day, midnight - 0 0 * * *
-* `@hourly` - Run once an hour, first minute - 0 * * * *
+* `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - `0 0 1 1 *`
+* `@monthly` - Run once a month, midnight, first of month - `0 0 1 * *`
+* `@weekly` - Run once a week, midnight on Sun - `0 0 * * 0`
+* `@daily` - Run once a day, midnight - `0 0 * * *`
+* `@hourly` - Run once an hour, first minute - `0 * * * *`
 
 Requirements
 ============
 
-- PHP 7.0+
+- PHP 7.1+
 - PHPUnit is required to run the unit tests
 - Composer is required to run the unit tests
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ PHP Cron Expression Parser
 The PHP cron expression parser can parse a CRON expression, determine if it is
 due to run, calculate the next run date of the expression, and calculate the previous
 run date of the expression.  You can calculate dates far into the future or past by
-skipping n number of matching dates.
+skipping **n** number of matching dates.
 
 The parser can handle increments of ranges (e.g. */12, 2-59/3), intervals (e.g. 0-9),
-lists (e.g. 1,2,3), W to find the nearest weekday for a given day of the month, L to
-find the last day of the month, L to find the last given weekday of a month, and hash
+lists (e.g. 1,2,3), **W** to find the nearest weekday for a given day of the month, **L** to
+find the last day of the month, **L** to find the last given weekday of a month, and hash
 (#) to find the nth weekday of a given month.
 
 More information about this fork can be found in the blog post [here](http://ctankersley.com/2017/10/12/cron-expression-update/). tl;dr - v2.0.0 is a major breaking change, and @dragonmantank can better take care of the project in a separate fork.

--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ Projects that Use cron-expression
 =================================
 * Part of the [Laravel Framework](https://github.com/laravel/framework/)
 * Available as a [Symfony Bundle - setono/cron-expression-bundle](https://github.com/Setono/CronExpressionBundle)
+* Framework agnostic, PHP-based job scheduler - [Crunz](https://github.com/lavary/crunz)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHP Cron Expression Parser
 ==========================
 
-[![Latest Stable Version](https://poser.pugx.org/dragonmantank/cron-expression/v/stable.png)](https://packagist.org/packages/dragonmantank/cron-expression) [![Total Downloads](https://poser.pugx.org/dragonmantank/cron-expression/downloads.png)](https://packagist.org/packages/dragonmantank/cron-expression) [![Build Status](https://secure.travis-ci.org/dragonmantank/cron-expression.png)](http://travis-ci.org/dragonmantank/cron-expression)
+[![Latest Stable Version](https://poser.pugx.org/dragonmantank/cron-expression/v/stable.png)](https://packagist.org/packages/dragonmantank/cron-expression) [![Total Downloads](https://poser.pugx.org/dragonmantank/cron-expression/downloads.png)](https://packagist.org/packages/dragonmantank/cron-expression) [![Build Status](https://secure.travis-ci.org/dragonmantank/cron-expression.png)](http://travis-ci.org/dragonmantank/cron-expression) [![StyleCI](https://github.styleci.io/repos/103715337/shield?branch=master)](https://github.styleci.io/repos/103715337)
 
 The PHP cron expression parser can parse a CRON expression, determine if it is
 due to run, calculate the next run date of the expression, and calculate the previous
@@ -64,6 +64,14 @@ A CRON expression is a string representing the schedule for a particular command
     |    |    +--------------- day of month (1 - 31)
     |    +-------------------- hour (0 - 23)
     +------------------------- min (0 - 59)
+
+This library also supports a few macros:
+
+* `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
+* `@monthly` - Run once a month, midnight, first of month - 0 0 1 * *
+* `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
+* `@daily` - Run once a day, midnight - 0 0 * * *
+* `@hourly` - Run once an hour, first minute - 0 * * * *
 
 Requirements
 ============

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=7.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~6.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "mtdowling/cron-expression": "^1.0"
     },
     "scripts": {
-        "phpstan": "./vendor/bin/phpstan analyse -l max src",
+        "phpstan": "./vendor/bin/phpstan analyse -l max src tests",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0"
+        "php": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.4"
+        "phpunit/phpunit": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,6 +30,11 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/Cron/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.3-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "webmozart/assert": "^1.7.0"
+        "webmozart/assert": "^1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^7.0|^8.0|^9.0",
-        "phpstan/phpstan-webmozart-assert": "^0.12.7",
+        "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpstan/extension-installer": "^1.0"
     },
     "autoload": {
@@ -35,7 +35,7 @@
         "mtdowling/cron-expression": "^1.0"
     },
     "scripts": {
-        "phpstan": "./vendor/bin/phpstan analyse -l max src tests",
+        "phpstan": "./vendor/bin/phpstan analyze",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,11 @@
     "scripts": {
         "phpstan": "./vendor/bin/phpstan analyze",
         "test": "phpunit"
+    },
+    "config": {
+        "allow-plugins": {
+            "ocramius/package-versions": true,
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "php": "^7.1|^8.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.11",
-        "phpunit/phpunit": "^6.4|^7.0"
+        "phpstan/phpstan": "^0.11|^0.12",
+        "phpunit/phpunit": "^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,21 @@
 {
-    "name": "mtdowling/cron-expression",
+    "name": "dragonmantank/cron-expression",
     "type": "library",
     "description": "CRON for PHP: Calculate the next or previous run date and determine if a CRON expression is due",
     "keywords": ["cron", "schedule"],
     "license": "MIT",
-    "authors": [{
-        "name": "Michael Dowling",
-        "email": "mtdowling@gmail.com",
-        "homepage": "https://github.com/mtdowling"
-    }],
+    "authors": [
+        {
+            "name": "Michael Dowling",
+            "email": "mtdowling@gmail.com",
+            "homepage": "https://github.com/mtdowling"
+        },
+        {
+            "name": "Chris Tankersley",
+            "email": "chris@ctankersley.com",
+            "homepage": "https://github.com/dragonmantank"
+        }
+    ],
     "require": {
         "php": ">=7.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.2",
         "phpstan/phpstan": "^0.11"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/Cron/"
+            "Cron\\Tests\\": "tests/Cron/"
         }
     },
     "extra": {
@@ -39,6 +39,6 @@
         }
     },
     "scripts": {
-        "phpstan": "./vendor/bin/phpstan analyse -l 1 src"
+        "phpstan": "./vendor/bin/phpstan analyse -l 0 src tests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
         "mtdowling/cron-expression": "^1.0"
     },
     "scripts": {
-        "phpstan": "./vendor/bin/phpstan analyse -l max src tests"
+        "phpstan": "./vendor/bin/phpstan analyse -l max src"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "phpstan/phpstan": "^0.11"
+        "php": "^7.2"
     },
     "require-dev": {
+        "phpstan/phpstan": "^0.11",
         "phpunit/phpunit": "^6.4|^7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
             "Cron\\Tests\\": "tests/Cron/"
         }
     },
+    "replace": {
+        "mtdowling/cron-expression": "^1.0"
+    },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan analyse -l 0 src tests"
     }

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,6 @@
             "Cron\\Tests\\": "tests/Cron/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.3-dev"
-        }
-    },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan analyse -l 0 src tests"
     }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0"
+        "php": "^7.1|^8.0",
+        "webmozart/assert": "^1.7.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12",

--- a/composer.json
+++ b/composer.json
@@ -6,18 +6,13 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Michael Dowling",
-            "email": "mtdowling@gmail.com",
-            "homepage": "https://github.com/mtdowling"
-        },
-        {
             "name": "Chris Tankersley",
             "email": "chris@ctankersley.com",
             "homepage": "https://github.com/dragonmantank"
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": "^7.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
         "php": "^7.1|^8.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.11|^0.12",
-        "phpunit/phpunit": "^7.0|^8.0|^9.0"
+        "phpstan/phpstan": "^0.12",
+        "phpunit/phpunit": "^7.0|^8.0|^9.0",
+        "phpstan/phpstan-webmozart-assert": "^0.12.7",
+        "phpstan/extension-installer": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -32,6 +34,6 @@
         "mtdowling/cron-expression": "^1.0"
     },
     "scripts": {
-        "phpstan": "./vendor/bin/phpstan analyse -l 0 src tests"
+        "phpstan": "./vendor/bin/phpstan analyse -l max src tests"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.0",
+        "phpstan/phpstan": "^0.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4|^7.0"
@@ -36,5 +37,8 @@
         "branch-alias": {
             "dev-master": "2.3-dev"
         }
+    },
+    "scripts": {
+        "phpstan": "./vendor/bin/phpstan analyse -l 1 src"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.2|^8.0",
         "webmozart/assert": "^1.7.0"
     },
     "require-dev": {
@@ -35,6 +35,7 @@
         "mtdowling/cron-expression": "^1.0"
     },
     "scripts": {
-        "phpstan": "./vendor/bin/phpstan analyse -l max src"
+        "phpstan": "./vendor/bin/phpstan analyse -l max src",
+        "test": "phpunit"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,15 @@
 parameters:
     checkMissingIterableValueType: false
+
+    ignoreErrors:
+        - '#Call to an undefined method DateTimeInterface::add\(\)#'
+        - '#Call to an undefined method DateTimeInterface::modify\(\)#'
+        - '#Call to an undefined method DateTimeInterface::setDate\(\)#'
+        - '#Call to an undefined method DateTimeInterface::setTime\(\)#'
+        - '#Call to an undefined method DateTimeInterface::setTimezone\(\)#'
+        - '#Call to an undefined method DateTimeInterface::sub\(\)#'
+
+    level: max
+
+    paths:
+        - src/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,2 @@
+parameters:
+    checkMissingIterableValueType: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="./vendor/autoload.php"
          colors="true"
@@ -8,18 +9,19 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
+
+    <coverage>
+        <include>
+            <directory suffix=".php">./src/Cron</directory>
+        </include>
+    </coverage>
 
     <testsuites>
         <testsuite name="Cron">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/Cron</directory>
-        </whitelist>
-    </filter>
 
 </phpunit>

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -31,7 +31,9 @@ abstract class AbstractField implements FieldInterface
      */
     protected $rangeEnd;
 
-
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->fullRange = range($this->rangeStart, $this->rangeEnd);
@@ -204,12 +206,18 @@ abstract class AbstractField implements FieldInterface
         return $values;
     }
 
+    /**
+     * Convert literal
+     *
+     * @param string $value
+     * @return string
+     */
     protected function convertLiterals($value)
     {
         if (count($this->literals)) {
             $key = array_search($value, $this->literals);
             if ($key !== false) {
-                return $key;
+                return (string) $key;
             }
         }
 

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -146,8 +146,9 @@ abstract class AbstractField implements FieldInterface
 
         // Generate the requested small range
         $rangeChunks = explode('-', $range, 2);
-        $rangeStart = $rangeChunks[0];
+        $rangeStart = (int) $rangeChunks[0];
         $rangeEnd = $rangeChunks[1] ?? $rangeStart;
+        $rangeEnd = (int) $rangeEnd;
 
         if ($rangeStart < $this->rangeStart || $rangeStart > $this->rangeEnd || $rangeStart > $rangeEnd) {
             throw new \OutOfRangeException('Invalid range start requested');

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -249,17 +249,6 @@ abstract class AbstractField implements FieldInterface
             return true;
         }
 
-        if (false !== strpos($value, '/')) {
-            [$range, $step] = explode('/', $value);
-
-            // Don't allow numeric ranges
-            if (is_numeric($range)) {
-                return false;
-            }
-
-            return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
-        }
-
         // Validate each chunk of a list individually
         if (false !== strpos($value, ',')) {
             foreach (explode(',', $value) as $listItem) {
@@ -269,6 +258,17 @@ abstract class AbstractField implements FieldInterface
             }
 
             return true;
+        }
+
+        if (false !== strpos($value, '/')) {
+            [$range, $step] = explode('/', $value);
+
+            // Don't allow numeric ranges
+            if (is_numeric($range)) {
+                return false;
+            }
+
+            return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
         }
 
         if (false !== strpos($value, '-')) {

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -152,7 +152,7 @@ abstract class AbstractField implements FieldInterface
         if ($step >= $this->rangeEnd) {
             $thisRange = [$this->fullRange[$step % \count($this->fullRange)]];
         } else {
-            $thisRange = range($rangeStart, $rangeEnd, $step);
+            $thisRange = range($rangeStart, $rangeEnd, (int) $step);
         }
 
         return \in_array($dateValue, $thisRange, true);

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -168,7 +168,11 @@ abstract class AbstractField implements FieldInterface
         if ($step > $this->rangeEnd) {
             $thisRange = [$this->fullRange[$step % \count($this->fullRange)]];
         } else {
-            $thisRange = range($rangeStart, $rangeEnd, (int) $step);
+            if ($step > ($rangeEnd - $rangeStart)) {
+                $thisRange[$rangeStart] = (int) $rangeStart;
+            } else {
+                $thisRange = range($rangeStart, $rangeEnd, (int) $step);
+            }
         }
 
         return \in_array($dateValue, $thisRange, true);

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -100,11 +100,12 @@ abstract class AbstractField implements FieldInterface
      */
     public function isInRange(int $dateValue, $value): bool
     {
-        $parts = array_map(function ($value) {
-            $value = trim($value);
+        $parts = array_map(
+            function ($value) {
+                $value = trim($value);
 
-            return $this->convertLiterals($value);
-        },
+                return $this->convertLiterals($value);
+            },
             explode('-', $value, 2)
         );
 

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -222,7 +222,7 @@ abstract class AbstractField implements FieldInterface
     protected function convertLiterals(string $value): string
     {
         if (\count($this->literals)) {
-            $key = array_search($value, $this->literals, true);
+            $key = array_search(strtoupper($value), $this->literals, true);
             if (false !== $key) {
                 return (string) $key;
             }

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -50,6 +50,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * Check to see if a field is satisfied by a value.
      *
+     * @internal
      * @param int $dateValue Date value to check
      * @param string $value Value to test
      *
@@ -71,6 +72,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * Check if a value is a range.
      *
+     * @internal
      * @param string $value Value to test
      *
      * @return bool
@@ -83,6 +85,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * Check if a value is an increments of ranges.
      *
+     * @internal
      * @param string $value Value to test
      *
      * @return bool
@@ -95,6 +98,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * Test if a value is within a range.
      *
+     * @internal
      * @param int $dateValue Set date value
      * @param string $value Value to test
      *
@@ -117,6 +121,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * Test if a value is within an increments of ranges (offset[-to]/step size).
      *
+     * @internal
      * @param int $dateValue Set date value
      * @param string $value Value to test
      *

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -139,11 +139,12 @@ abstract class AbstractField implements FieldInterface
             throw new \OutOfRangeException('Invalid range end requested');
         }
 
-        if ($step > ($rangeEnd - $rangeStart) + 1) {
-            throw new \OutOfRangeException('Step cannot be greater than total range');
+        // Steps larger than the range need to wrap around and be handled slightly differently than smaller steps
+        if ($step >= $this->rangeEnd) {
+            $thisRange = [$this->fullRange[$step % count($this->fullRange)]];
+        } else {
+            $thisRange = range($rangeStart, $rangeEnd, $step);
         }
-
-        $thisRange = range($rangeStart, $rangeEnd, $step);
 
         return in_array($dateValue, $thisRange);
     }
@@ -186,9 +187,13 @@ abstract class AbstractField implements FieldInterface
                 $offset = $range[0];
                 $to = isset($range[1]) ? $range[1] : $max;
             }
-            $offset = $offset == '*' ? 0 : $offset;
-            for ($i = $offset; $i <= $to; $i += $stepSize) {
-                $values[] = (int)$i;
+            $offset = $offset == '*' ? $this->rangeStart : $offset;
+            if ($stepSize >= $this->rangeEnd) {
+                $values = [$this->fullRange[$stepSize % count($this->fullRange)]];
+            } else {
+                for ($i = $offset; $i <= $to; $i += $stepSize) {
+                    $values[] = (int)$i;
+                }
             }
             sort($values);
         }

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -90,7 +90,14 @@ abstract class AbstractField implements FieldInterface
      */
     public function isInRange($dateValue, $value)
     {
-        $parts = array_map('trim', explode('-', $value, 2));
+        $parts = array_map(function($value) {
+                $value = trim($value);
+                $value = $this->convertLiterals($value);
+                return $value;
+            },
+            explode('-', $value, 2)
+        );
+
 
         return $dateValue >= $parts[0] && $dateValue <= $parts[1];
     }
@@ -152,6 +159,7 @@ abstract class AbstractField implements FieldInterface
     public function getRangeForExpression($expression, $max)
     {
         $values = array();
+        $expression = $this->convertLiterals($expression);
 
         if (strpos($expression, ',') !== false) {
             $ranges = explode(',', $expression);
@@ -166,6 +174,8 @@ abstract class AbstractField implements FieldInterface
         if ($this->isRange($expression) || $this->isIncrementsOfRanges($expression)) {
             if (!$this->isIncrementsOfRanges($expression)) {
                 list ($offset, $to) = explode('-', $expression);
+                $offset = $this->convertLiterals($offset);
+                $to = $this->convertLiterals($to);
                 $stepSize = 1;
             }
             else {

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -257,10 +257,16 @@ abstract class AbstractField implements FieldInterface
             return $this->validate($chunks[0]) && $this->validate($chunks[1]);
         }
 
-        // We should have a numeric by now, so coerce this into an integer
-        if (filter_var($value, FILTER_VALIDATE_INT) !== false) {
-            $value = (int) $value;
+        if (!is_numeric($value)) {
+            return false;
         }
+
+        if (is_float($value) || strpos($value, '.') !== false) {
+            return false;
+        }
+
+        // We should have a numeric by now, so coerce this into an integer
+        $value = (int) $value;
 
         return in_array($value, $this->fullRange, true);
     }

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -157,8 +157,15 @@ abstract class AbstractField implements FieldInterface
             throw new \OutOfRangeException('Invalid range end requested');
         }
 
-        // Steps larger than the range need to wrap around and be handled slightly differently than smaller steps
-        if ($step >= $this->rangeEnd) {
+        // Steps larger than the range need to wrap around and be handled
+        // slightly differently than smaller steps
+
+        // UPDATE - This is actually false. The C implementation will allow a
+        // larger step as valid syntax, it never wraps around. It will stop
+        // once it hits the end. Unfortunately this means in future versions
+        // we will not wrap around. However, because the logic exists today
+        // per the above documentation, fixing the bug from #89
+        if ($step > $this->rangeEnd) {
             $thisRange = [$this->fullRange[$step % \count($this->fullRange)]];
         } else {
             $thisRange = range($rangeStart, $rangeEnd, (int) $step);

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -48,7 +48,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * Check to see if a field is satisfied by a value.
      *
-     * @param string $dateValue Date value to check
+     * @param int $dateValue Date value to check
      * @param string $value Value to test
      *
      * @return bool
@@ -114,7 +114,7 @@ abstract class AbstractField implements FieldInterface
     /**
      * Test if a value is within an increments of ranges (offset[-to]/step size).
      *
-     * @param string $dateValue Set date value
+     * @param int $dateValue Set date value
      * @param string $value Value to test
      *
      * @return bool
@@ -126,6 +126,7 @@ abstract class AbstractField implements FieldInterface
         $step = $chunks[1] ?? 0;
 
         // No step or 0 steps aren't cool
+        /** @phpstan-ignore-next-line */
         if (null === $step || '0' === $step || 0 === $step) {
             return false;
         }
@@ -289,7 +290,7 @@ abstract class AbstractField implements FieldInterface
             return false;
         }
 
-        if (\is_float($value) || false !== strpos($value, '.')) {
+        if (false !== strpos($value, '.')) {
             return false;
         }
 

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -153,6 +153,16 @@ abstract class AbstractField implements FieldInterface
     {
         $values = array();
 
+        if (strpos($expression, ',') !== false) {
+            $ranges = explode(',', $expression);
+            $values = [];
+            foreach ($ranges as $range) {
+                $expanded = $this->getRangeForExpression($range, $this->rangeEnd);
+                $values = array_merge($values, $expanded);
+            }
+            return $values;
+        }
+
         if ($this->isRange($expression) || $this->isIncrementsOfRanges($expression)) {
             if (!$this->isIncrementsOfRanges($expression)) {
                 list ($offset, $to) = explode('-', $expression);
@@ -168,7 +178,7 @@ abstract class AbstractField implements FieldInterface
             }
             $offset = $offset == '*' ? 0 : $offset;
             for ($i = $offset; $i <= $to; $i += $stepSize) {
-                $values[] = $i;
+                $values[] = (int)$i;
             }
             sort($values);
         }
@@ -206,14 +216,19 @@ abstract class AbstractField implements FieldInterface
             return true;
         }
 
-        // You cannot have a range and a list at the same time
-        if (strpos($value, ',') !== false && strpos($value, '-') !== false) {
-            return false;
-        }
-
         if (strpos($value, '/') !== false) {
             list($range, $step) = explode('/', $value);
             return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
+        }
+
+        // Validate each chunk of a list individually
+        if (strpos($value, ',') !== false) {
+            foreach (explode(',', $value) as $listItem) {
+                if (!$this->validate($listItem)) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         if (strpos($value, '-') !== false) {
@@ -230,16 +245,6 @@ abstract class AbstractField implements FieldInterface
             }
 
             return $this->validate($chunks[0]) && $this->validate($chunks[1]);
-        }
-
-        // Validate each chunk of a list individually
-        if (strpos($value, ',') !== false) {
-            foreach (explode(',', $value) as $listItem) {
-                if (!$this->validate($listItem)) {
-                    return false;
-                }
-            }
-            return true;
         }
 
         // We should have a numeric by now, so coerce this into an integer

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -250,6 +250,11 @@ abstract class AbstractField implements FieldInterface
         if (false !== strpos($value, '/')) {
             [$range, $step] = explode('/', $value);
 
+            // Don't allow numeric ranges
+            if (is_numeric($range)) {
+                return false;
+            }
+
             return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
         }
 

--- a/src/Cron/AbstractField.php
+++ b/src/Cron/AbstractField.php
@@ -1,38 +1,44 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 /**
- * Abstract CRON expression field
+ * Abstract CRON expression field.
  */
 abstract class AbstractField implements FieldInterface
 {
     /**
-     * Full range of values that are allowed for this field type
+     * Full range of values that are allowed for this field type.
+     *
      * @var array
      */
     protected $fullRange = [];
 
     /**
-     * Literal values we need to convert to integers
+     * Literal values we need to convert to integers.
+     *
      * @var array
      */
     protected $literals = [];
 
     /**
-     * Start value of the full range
-     * @var integer
+     * Start value of the full range.
+     *
+     * @var int
      */
     protected $rangeStart;
 
     /**
-     * End value of the full range
-     * @var integer
+     * End value of the full range.
+     *
+     * @var int
      */
     protected $rangeEnd;
 
     /**
-     * Constructor
+     * Constructor.
      */
     public function __construct()
     {
@@ -40,98 +46,99 @@ abstract class AbstractField implements FieldInterface
     }
 
     /**
-     * Check to see if a field is satisfied by a value
+     * Check to see if a field is satisfied by a value.
      *
      * @param string $dateValue Date value to check
-     * @param string $value     Value to test
+     * @param string $value Value to test
      *
      * @return bool
      */
-    public function isSatisfied($dateValue, $value)
+    public function isSatisfied(int $dateValue, string $value): bool
     {
         if ($this->isIncrementsOfRanges($value)) {
             return $this->isInIncrementsOfRanges($dateValue, $value);
-        } elseif ($this->isRange($value)) {
+        }
+
+        if ($this->isRange($value)) {
             return $this->isInRange($dateValue, $value);
         }
 
-        return $value == '*' || $dateValue == $value;
+        return '*' === $value || $dateValue === (int) $value;
     }
 
     /**
-     * Check if a value is a range
+     * Check if a value is a range.
      *
      * @param string $value Value to test
      *
      * @return bool
      */
-    public function isRange($value)
+    public function isRange(string $value): bool
     {
-        return strpos($value, '-') !== false;
+        return false !== strpos($value, '-');
     }
 
     /**
-     * Check if a value is an increments of ranges
+     * Check if a value is an increments of ranges.
      *
      * @param string $value Value to test
      *
      * @return bool
      */
-    public function isIncrementsOfRanges($value)
+    public function isIncrementsOfRanges(string $value): bool
     {
-        return strpos($value, '/') !== false;
+        return false !== strpos($value, '/');
     }
 
     /**
-     * Test if a value is within a range
+     * Test if a value is within a range.
      *
-     * @param string $dateValue Set date value
-     * @param string $value     Value to test
+     * @param int $dateValue Set date value
+     * @param string $value Value to test
      *
      * @return bool
      */
-    public function isInRange($dateValue, $value)
+    public function isInRange(int $dateValue, $value): bool
     {
-        $parts = array_map(function($value) {
-                $value = trim($value);
-                $value = $this->convertLiterals($value);
-                return $value;
-            },
+        $parts = array_map(function ($value) {
+            $value = trim($value);
+
+            return $this->convertLiterals($value);
+        },
             explode('-', $value, 2)
         );
-
 
         return $dateValue >= $parts[0] && $dateValue <= $parts[1];
     }
 
     /**
-     * Test if a value is within an increments of ranges (offset[-to]/step size)
+     * Test if a value is within an increments of ranges (offset[-to]/step size).
      *
      * @param string $dateValue Set date value
-     * @param string $value     Value to test
+     * @param string $value Value to test
      *
      * @return bool
      */
-    public function isInIncrementsOfRanges($dateValue, $value)
+    public function isInIncrementsOfRanges(int $dateValue, string $value): bool
     {
         $chunks = array_map('trim', explode('/', $value, 2));
         $range = $chunks[0];
-        $step = isset($chunks[1]) ? $chunks[1] : 0;
+        $step = $chunks[1] ?? 0;
 
         // No step or 0 steps aren't cool
-        if (is_null($step) || '0' === $step || 0 === $step) {
+        if (null === $step || '0' === $step || 0 === $step) {
             return false;
         }
 
         // Expand the * to a full range
-        if ('*' == $range) {
+        if ('*' === $range) {
             $range = $this->rangeStart . '-' . $this->rangeEnd;
         }
 
         // Generate the requested small range
         $rangeChunks = explode('-', $range, 2);
         $rangeStart = $rangeChunks[0];
-        $rangeEnd = isset($rangeChunks[1]) ? $rangeChunks[1] : $rangeStart;
+        $rangeEnd = $rangeChunks[1] ?? $rangeStart;
 
         if ($rangeStart < $this->rangeStart || $rangeStart > $this->rangeEnd || $rangeStart > $rangeEnd) {
             throw new \OutOfRangeException('Invalid range start requested');
@@ -143,80 +150,80 @@ abstract class AbstractField implements FieldInterface
 
         // Steps larger than the range need to wrap around and be handled slightly differently than smaller steps
         if ($step >= $this->rangeEnd) {
-            $thisRange = [$this->fullRange[$step % count($this->fullRange)]];
+            $thisRange = [$this->fullRange[$step % \count($this->fullRange)]];
         } else {
             $thisRange = range($rangeStart, $rangeEnd, $step);
         }
 
-        return in_array($dateValue, $thisRange);
+        return \in_array($dateValue, $thisRange, true);
     }
 
     /**
-     * Returns a range of values for the given cron expression
+     * Returns a range of values for the given cron expression.
      *
      * @param string $expression The expression to evaluate
-     * @param int $max           Maximum offset for range
+     * @param int $max Maximum offset for range
      *
      * @return array
      */
-    public function getRangeForExpression($expression, $max)
+    public function getRangeForExpression(string $expression, int $max): array
     {
-        $values = array();
+        $values = [];
         $expression = $this->convertLiterals($expression);
 
-        if (strpos($expression, ',') !== false) {
+        if (false !== strpos($expression, ',')) {
             $ranges = explode(',', $expression);
             $values = [];
             foreach ($ranges as $range) {
                 $expanded = $this->getRangeForExpression($range, $this->rangeEnd);
                 $values = array_merge($values, $expanded);
             }
+
             return $values;
         }
 
         if ($this->isRange($expression) || $this->isIncrementsOfRanges($expression)) {
             if (!$this->isIncrementsOfRanges($expression)) {
-                list ($offset, $to) = explode('-', $expression);
+                [$offset, $to] = explode('-', $expression);
                 $offset = $this->convertLiterals($offset);
                 $to = $this->convertLiterals($to);
                 $stepSize = 1;
-            }
-            else {
+            } else {
                 $range = array_map('trim', explode('/', $expression, 2));
-                $stepSize = isset($range[1]) ? $range[1] : 0;
+                $stepSize = $range[1] ?? 0;
                 $range = $range[0];
                 $range = explode('-', $range, 2);
                 $offset = $range[0];
-                $to = isset($range[1]) ? $range[1] : $max;
+                $to = $range[1] ?? $max;
             }
-            $offset = $offset == '*' ? $this->rangeStart : $offset;
+            $offset = '*' === $offset ? $this->rangeStart : $offset;
             if ($stepSize >= $this->rangeEnd) {
-                $values = [$this->fullRange[$stepSize % count($this->fullRange)]];
+                $values = [$this->fullRange[$stepSize % \count($this->fullRange)]];
             } else {
                 for ($i = $offset; $i <= $to; $i += $stepSize) {
-                    $values[] = (int)$i;
+                    $values[] = (int) $i;
                 }
             }
             sort($values);
-        }
-        else {
-            $values = array($expression);
+        } else {
+            $values = [$expression];
         }
 
         return $values;
     }
 
     /**
-     * Convert literal
+     * Convert literal.
      *
      * @param string $value
+     *
      * @return string
      */
-    protected function convertLiterals($value)
+    protected function convertLiterals(string $value): string
     {
-        if (count($this->literals)) {
-            $key = array_search($value, $this->literals);
-            if ($key !== false) {
+        if (\count($this->literals)) {
+            $key = array_search($value, $this->literals, true);
+            if (false !== $key) {
                 return (string) $key;
             }
         }
@@ -225,12 +232,13 @@ abstract class AbstractField implements FieldInterface
     }
 
     /**
-     * Checks to see if a value is valid for the field
+     * Checks to see if a value is valid for the field.
      *
      * @param string $value
+     *
      * @return bool
      */
-    public function validate($value)
+    public function validate(string $value): bool
     {
         $value = $this->convertLiterals($value);
 
@@ -239,22 +247,24 @@ abstract class AbstractField implements FieldInterface
             return true;
         }
 
-        if (strpos($value, '/') !== false) {
-            list($range, $step) = explode('/', $value);
+        if (false !== strpos($value, '/')) {
+            [$range, $step] = explode('/', $value);
+
             return $this->validate($range) && filter_var($step, FILTER_VALIDATE_INT);
         }
 
         // Validate each chunk of a list individually
-        if (strpos($value, ',') !== false) {
+        if (false !== strpos($value, ',')) {
             foreach (explode(',', $value) as $listItem) {
                 if (!$this->validate($listItem)) {
                     return false;
                 }
             }
+
             return true;
         }
 
-        if (strpos($value, '-') !== false) {
+        if (false !== strpos($value, '-')) {
             if (substr_count($value, '-') > 1) {
                 return false;
             }
@@ -263,7 +273,7 @@ abstract class AbstractField implements FieldInterface
             $chunks[0] = $this->convertLiterals($chunks[0]);
             $chunks[1] = $this->convertLiterals($chunks[1]);
 
-            if ('*' == $chunks[0] || '*' == $chunks[1]) {
+            if ('*' === $chunks[0] || '*' === $chunks[1]) {
                 return false;
             }
 
@@ -274,13 +284,13 @@ abstract class AbstractField implements FieldInterface
             return false;
         }
 
-        if (is_float($value) || strpos($value, '.') !== false) {
+        if (\is_float($value) || false !== strpos($value, '.')) {
             return false;
         }
 
         // We should have a numeric by now, so coerce this into an integer
         $value = (int) $value;
 
-        return in_array($value, $this->fullRange, true);
+        return \in_array($value, $this->fullRange, true);
     }
 }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -177,6 +177,7 @@ class CronExpression
      *
      * @param string $expression CRON expression (e.g. '8 * * * *')
      * @param null|FieldFactoryInterface $fieldFactory Factory to create cron fields
+     * @throws InvalidArgumentException
      */
     public function __construct(string $expression, FieldFactoryInterface $fieldFactory = null)
     {

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -48,22 +48,22 @@ class CronExpression
     /**
      * @var array CRON expression parts
      */
-    private $cronParts;
+    protected $cronParts;
 
     /**
      * @var FieldFactoryInterface CRON field factory
      */
-    private $fieldFactory;
+    protected $fieldFactory;
 
     /**
      * @var int Max iteration count when searching for next run date
      */
-    private $maxIterationCount = 1000;
+    protected $maxIterationCount = 1000;
 
     /**
      * @var array Order in which to test of cron parts
      */
-    private static $order = [
+    protected static $order = [
         self::YEAR,
         self::MONTH,
         self::DAY,

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -32,7 +32,7 @@ class CronExpression
     public const DAY = 2;
     public const MONTH = 3;
     public const WEEKDAY = 4;
-    
+
     /** @deprecated */
     public const YEAR = 5;
 
@@ -42,6 +42,7 @@ class CronExpression
         '@monthly' => '0 0 1 * *',
         '@weekly' => '0 0 * * 0',
         '@daily' => '0 0 * * *',
+        '@midnight' => '0 0 * * *',
         '@hourly' => '0 * * * *',
     ];
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -394,6 +394,9 @@ class CronExpression
             usort($combined, function ($a, $b) {
                 return $a->format('Y-m-d H:i:s') <=> $b->format('Y-m-d H:i:s');
             });
+            if ($invert) {
+                $combined = array_reverse($combined);
+            }
 
             return $combined[$nth];
         }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use DateTime;
@@ -20,16 +22,16 @@ use RuntimeException;
  * minute [0-59], hour [0-23], day of month, month [1-12|JAN-DEC], day of week
  * [1-7|MON-SUN], and an optional year.
  *
- * @link http://en.wikipedia.org/wiki/Cron
+ * @see http://en.wikipedia.org/wiki/Cron
  */
 class CronExpression
 {
-    const MINUTE = 0;
-    const HOUR = 1;
-    const DAY = 2;
-    const MONTH = 3;
-    const WEEKDAY = 4;
-    const YEAR = 5;
+    public const MINUTE = 0;
+    public const HOUR = 1;
+    public const DAY = 2;
+    public const MONTH = 3;
+    public const WEEKDAY = 4;
+    public const YEAR = 5;
 
     /**
      * @var array CRON expression parts
@@ -49,7 +51,7 @@ class CronExpression
     /**
      * @var array Order in which to test of cron parts
      */
-    private static $order = array(self::YEAR, self::MONTH, self::DAY, self::WEEKDAY, self::HOUR, self::MINUTE);
+    private static $order = [self::YEAR, self::MONTH, self::DAY, self::WEEKDAY, self::HOUR, self::MINUTE];
 
     /**
      * Factory method to create a new CronExpression.
@@ -63,20 +65,20 @@ class CronExpression
      *      `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
      *      `@daily` - Run once a day, midnight - 0 0 * * *
      *      `@hourly` - Run once an hour, first minute - 0 * * * *
-     * @param FieldFactory|null $fieldFactory Field factory to use
+     * @param null|FieldFactory $fieldFactory Field factory to use
      *
      * @return CronExpression
      */
-    public static function factory($expression, FieldFactory $fieldFactory = null)
+    public static function factory(string $expression, FieldFactory $fieldFactory = null): CronExpression
     {
-        $mappings = array(
+        $mappings = [
             '@yearly' => '0 0 1 1 *',
             '@annually' => '0 0 1 1 *',
             '@monthly' => '0 0 1 * *',
             '@weekly' => '0 0 * * 0',
             '@daily' => '0 0 * * *',
-            '@hourly' => '0 * * * *'
-        );
+            '@hourly' => '0 * * * *',
+        ];
 
         if (isset($mappings[$expression])) {
             $expression = $mappings[$expression];
@@ -88,12 +90,13 @@ class CronExpression
     /**
      * Validate a CronExpression.
      *
-     * @param string $expression The CRON expression to validate.
+     * @param string $expression the CRON expression to validate
      *
      * @return bool True if a valid CRON expression was passed. False if not.
+     *
      * @see \Cron\CronExpression::factory
      */
-    public static function isValidExpression($expression)
+    public static function isValidExpression(string $expression): bool
     {
         try {
             self::factory($expression);
@@ -105,29 +108,30 @@ class CronExpression
     }
 
     /**
-     * Parse a CRON expression
+     * Parse a CRON expression.
      *
-     * @param string       $expression   CRON expression (e.g. '8 * * * *')
-     * @param FieldFactory|null $fieldFactory Factory to create cron fields
+     * @param string $expression CRON expression (e.g. '8 * * * *')
+     * @param null|FieldFactory $fieldFactory Factory to create cron fields
      */
-    public function __construct($expression, FieldFactory $fieldFactory = null)
+    public function __construct(string $expression, FieldFactory $fieldFactory = null)
     {
         $this->fieldFactory = $fieldFactory;
         $this->setExpression($expression);
     }
 
     /**
-     * Set or change the CRON expression
+     * Set or change the CRON expression.
      *
      * @param string $value CRON expression (e.g. 8 * * * *)
      *
-     * @return CronExpression
      * @throws \InvalidArgumentException if not a valid CRON expression
+     *
+     * @return CronExpression
      */
-    public function setExpression($value)
+    public function setExpression(string $value): CronExpression
     {
         $this->cronParts = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
-        if (count($this->cronParts) < 5) {
+        if (\count($this->cronParts) < 5) {
             throw new InvalidArgumentException(
                 $value . ' is not a valid CRON expression'
             );
@@ -141,15 +145,16 @@ class CronExpression
     }
 
     /**
-     * Set part of the CRON expression
+     * Set part of the CRON expression.
      *
-     * @param int    $position The position of the CRON expression to set
-     * @param string $value    The value to set
+     * @param int $position The position of the CRON expression to set
+     * @param string $value The value to set
+     *
+     * @throws \InvalidArgumentException if the value is not valid for the part
      *
      * @return CronExpression
-     * @throws \InvalidArgumentException if the value is not valid for the part
      */
-    public function setPart($position, $value)
+    public function setPart(int $position, string $value): CronExpression
     {
         if (!$this->fieldFactory->getField($position)->validate($value)) {
             throw new InvalidArgumentException(
@@ -163,13 +168,13 @@ class CronExpression
     }
 
     /**
-     * Set max iteration count for searching next run dates
+     * Set max iteration count for searching next run dates.
      *
      * @param int $maxIterationCount Max iteration count when searching for next run date
      *
      * @return CronExpression
      */
-    public function setMaxIterationCount($maxIterationCount)
+    public function setMaxIterationCount(int $maxIterationCount): CronExpression
     {
         $this->maxIterationCount = $maxIterationCount;
 
@@ -177,61 +182,69 @@ class CronExpression
     }
 
     /**
-     * Get a next run date relative to the current date or a specific date
+     * Get a next run date relative to the current date or a specific date.
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning a
-     *                                           matching next run date.  0, the default, will return the current
-     *                                           date and time if the next run date falls on the current date and
-     *                                           time.  Setting this value to 1 will skip the first match and go to
-     *                                           the second match.  Setting this value to 2 will skip the first 2
-     *                                           matches and so on.
-     * @param bool             $allowCurrentDate Set to TRUE to return the current date if
-     *                                           it matches the cron expression.
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param \DateTime|string $currentTime Relative calculation date
+     * @param int $nth Number of matches to skip before returning a
+     *                 matching next run date.  0, the default, will return the current
+     *                 date and time if the next run date falls on the current date and
+     *                 time.  Setting this value to 1 will skip the first match and go to
+     *                 the second match.  Setting this value to 2 will skip the first 2
+     *                 matches and so on.
+     * @param bool $allowCurrentDate set to TRUE to return the current date if
+     *                               it matches the cron expression
+     * @param null|string $timeZone TimeZone to use instead of the system default
+     *
+     * @throws \RuntimeException on too many iterations
+     * @throws \Exception
      *
      * @return \DateTime
-     * @throws \RuntimeException on too many iterations
      */
-    public function getNextRunDate($currentTime = 'now', $nth = 0, $allowCurrentDate = false, $timeZone = null)
+    public function getNextRunDate($currentTime = 'now', int $nth = 0, bool $allowCurrentDate = false, $timeZone = null): DateTime
     {
         return $this->getRunDate($currentTime, $nth, false, $allowCurrentDate, $timeZone);
     }
 
     /**
-     * Get a previous run date relative to the current date or a specific date
+     * Get a previous run date relative to the current date or a specific date.
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param \DateTime|string $currentTime Relative calculation date
+     * @param int $nth Number of matches to skip before returning
+     * @param bool $allowCurrentDate Set to TRUE to return the
+     *                               current date if it matches the cron expression
+     * @param null|string $timeZone TimeZone to use instead of the system default
+     *
+     * @throws \RuntimeException on too many iterations
+     * @throws \Exception
      *
      * @return \DateTime
-     * @throws \RuntimeException on too many iterations
+     *
      * @see \Cron\CronExpression::getNextRunDate
      */
-    public function getPreviousRunDate($currentTime = 'now', $nth = 0, $allowCurrentDate = false, $timeZone = null)
+    public function getPreviousRunDate($currentTime = 'now', int $nth = 0, bool $allowCurrentDate = false, $timeZone = null): DateTime
     {
         return $this->getRunDate($currentTime, $nth, true, $allowCurrentDate, $timeZone);
     }
 
     /**
-     * Get multiple run dates starting at the current date or a specific date
+     * Get multiple run dates starting at the current date or a specific date.
      *
-     * @param int              $total            Set the total number of dates to calculate
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param bool             $invert           Set to TRUE to retrieve previous dates
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param int $total Set the total number of dates to calculate
+     * @param \DateTime|string $currentTime Relative calculation date
+     * @param bool $invert Set to TRUE to retrieve previous dates
+     * @param bool $allowCurrentDate Set to TRUE to return the
+     *                               current date if it matches the cron expression
+     * @param null|string $timeZone TimeZone to use instead of the system default
+     *
+     * @throws Exception
      *
      * @return array Returns an array of run dates
      */
-    public function getMultipleRunDates($total, $currentTime = 'now', $invert = false, $allowCurrentDate = false, $timeZone = null)
+    public function getMultipleRunDates(int $total, $currentTime = 'now', bool $invert = false, bool $allowCurrentDate = false, $timeZone = null): array
     {
-        $matches = array();
-        for ($i = 0; $i < max(0, $total); $i++) {
+        $matches = [];
+        $max = max(0, $total);
+        for ($i = 0; $i < $max; ++$i) {
             try {
                 $matches[] = $this->getRunDate($currentTime, $i, $invert, $allowCurrentDate, $timeZone);
             } catch (RuntimeException $e) {
@@ -243,19 +256,21 @@ class CronExpression
     }
 
     /**
-     * Get all or part of the CRON expression
+     * Get all or part of the CRON expression.
      *
-     * @param string $part Specify the part to retrieve or NULL to get the full
-     *                     cron schedule string.
+     * @param string $part specify the part to retrieve or NULL to get the full
+     *                     cron schedule string
      *
-     * @return string|null Returns the CRON expression, a part of the
+     * @return null|string Returns the CRON expression, a part of the
      *                     CRON expression, or NULL if the part was specified but not found
      */
-    public function getExpression($part = null)
+    public function getExpression($part = null): ?string
     {
         if (null === $part) {
             return implode(' ', $this->cronParts);
-        } elseif (array_key_exists($part, $this->cronParts)) {
+        }
+
+        if (array_key_exists($part, $this->cronParts)) {
             return $this->cronParts[$part];
         }
 
@@ -267,9 +282,9 @@ class CronExpression
      *
      * @return string Full CRON expression
      */
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->getExpression();
+        return (string) $this->getExpression();
     }
 
     /**
@@ -277,12 +292,14 @@ class CronExpression
      * specific date.  This method assumes that the current number of
      * seconds are irrelevant, and should be called once per minute.
      *
-     * @param string|\DateTime $currentTime Relative calculation date
-     * @param null|string      $timeZone    TimeZone to use instead of the system default
+     * @param \DateTime|string $currentTime Relative calculation date
+     * @param null|string $timeZone TimeZone to use instead of the system default
+     *
+     * @throws Exception
      *
      * @return bool Returns TRUE if the cron is due to run or FALSE if not
      */
-    public function isDue($currentTime = 'now', $timeZone = null)
+    public function isDue($currentTime = 'now', $timeZone = null): ?bool
     {
         $timeZone = $this->determineTimeZone($currentTime, $timeZone);
 
@@ -295,7 +312,7 @@ class CronExpression
         } else {
             $currentTime = new DateTime($currentTime);
         }
-        $currentTime->setTimeZone(new DateTimeZone($timeZone));
+        $currentTime->setTimezone(new DateTimeZone($timeZone));
 
         // drop the seconds to 0
         $currentTime = DateTime::createFromFormat('Y-m-d H:i', $currentTime->format('Y-m-d H:i'));
@@ -308,19 +325,21 @@ class CronExpression
     }
 
     /**
-     * Get the next or previous run date of the expression relative to a date
+     * Get the next or previous run date of the expression relative to a date.
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning
-     * @param bool             $invert           Set to TRUE to go backwards in time
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param string|null      $timeZone         TimeZone to use instead of the system default
+     * @param \DateTime|string $currentTime Relative calculation date
+     * @param int $nth Number of matches to skip before returning
+     * @param bool $invert Set to TRUE to go backwards in time
+     * @param bool $allowCurrentDate Set to TRUE to return the
+     *                               current date if it matches the cron expression
+     * @param null|string $timeZone TimeZone to use instead of the system default
+     *
+     * @throws \RuntimeException on too many iterations
+     * @throws Exception
      *
      * @return \DateTime
-     * @throws \RuntimeException on too many iterations
      */
-    protected function getRunDate($currentTime = null, $nth = 0, $invert = false, $allowCurrentDate = false, $timeZone = null)
+    protected function getRunDate($currentTime = null, int $nth = 0, bool $invert = false, bool $allowCurrentDate = false, $timeZone = null): DateTime
     {
         $timeZone = $this->determineTimeZone($currentTime, $timeZone);
 
@@ -332,14 +351,14 @@ class CronExpression
             $currentDate = new DateTime($currentTime ?: 'now');
         }
 
-        $currentDate->setTimeZone(new DateTimeZone($timeZone));
-        $currentDate->setTime($currentDate->format('H'), $currentDate->format('i'), 0);
+        $currentDate->setTimezone(new DateTimeZone($timeZone));
+        $currentDate->setTime((int) $currentDate->format('H'), (int) $currentDate->format('i'), 0);
+
         $nextRun = clone $currentDate;
-        $nth = (int) $nth;
 
         // We don't have to satisfy * or null fields
-        $parts = array();
-        $fields = array();
+        $parts = [];
+        $fields = [];
         foreach (self::$order as $position) {
             $part = $this->getExpression($position);
             if (null === $part || '*' === $part) {
@@ -350,19 +369,19 @@ class CronExpression
         }
 
         // Set a hard limit to bail on an impossible date
-        for ($i = 0; $i < $this->maxIterationCount; $i++) {
-
+        for ($i = 0; $i < $this->maxIterationCount; ++$i) {
             foreach ($parts as $position => $part) {
                 $satisfied = false;
                 // Get the field object used to validate this part
                 $field = $fields[$position];
                 // Check if this is singular or a list
-                if (strpos($part, ',') === false) {
+                if (false === strpos($part, ',')) {
                     $satisfied = $field->isSatisfiedBy($nextRun, $part);
                 } else {
                     foreach (array_map('trim', explode(',', $part)) as $listPart) {
                         if ($field->isSatisfiedBy($nextRun, $listPart)) {
                             $satisfied = true;
+
                             break;
                         }
                     }
@@ -371,13 +390,15 @@ class CronExpression
                 // If the field is not satisfied, then start over
                 if (!$satisfied) {
                     $field->increment($nextRun, $invert, $part);
+
                     continue 2;
                 }
             }
 
             // Skip this match if needed
             if ((!$allowCurrentDate && $nextRun == $currentDate) || --$nth > -1) {
-                $this->fieldFactory->getField(0)->increment($nextRun, $invert, isset($parts[0]) ? $parts[0] : null);
+                $this->fieldFactory->getField(0)->increment($nextRun, $invert, $parts[0] ?? null);
+
                 continue;
             }
 
@@ -392,19 +413,19 @@ class CronExpression
     /**
      * Workout what timeZone should be used.
      *
-     * @param string|\DateTimeInterface $currentTime      Relative calculation date
-     * @param string|null               $timeZone         TimeZone to use instead of the system default
+     * @param \DateTimeInterface|string $currentTime Relative calculation date
+     * @param null|string $timeZone TimeZone to use instead of the system default
      *
      * @return string
      */
-    protected function determineTimeZone($currentTime, $timeZone)
+    protected function determineTimeZone($currentTime, $timeZone): string
     {
-        if (! is_null($timeZone)) {
+        if (null !== $timeZone) {
             return $timeZone;
         }
 
-        if ($currentTime instanceOf DateTimeInterface) {
-            return $currentTime->getTimeZone()->getName();
+        if ($currentTime instanceof DateTimeInterface) {
+            return $currentTime->getTimezone()->getName();
         }
 
         return date_default_timezone_get();

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -201,13 +201,22 @@ class CronExpression
         $split = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
         Assert::isArray($split);
 
-        $this->cronParts = $split;
-        if (\count($this->cronParts) < 5) {
+        $notEnoughParts = \count($split) < 5;
+
+        $questionMarkInInvalidPart = array_key_exists(0, $split) && $split[0] === '?'
+            || array_key_exists(1, $split) && $split[1] === '?'
+            || array_key_exists(3, $split) && $split[3] === '?';
+
+        $tooManyQuestionMarks = array_key_exists(2, $split) && $split[2] === '?'
+            && array_key_exists(4, $split) && $split[4] === '?';
+
+        if ($notEnoughParts || $questionMarkInInvalidPart || $tooManyQuestionMarks) {
             throw new InvalidArgumentException(
                 $value . ' is not a valid CRON expression'
             );
         }
 
+        $this->cronParts = $split;
         foreach ($this->cronParts as $position => $part) {
             $this->setPart($position, $part);
         }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -312,7 +312,7 @@ class CronExpression
         $currentTime->setTimezone(new DateTimeZone($timeZone));
 
         // drop the seconds to 0
-        $currentTime = DateTime::createFromFormat('Y-m-d H:i', $currentTime->format('Y-m-d H:i'));
+        $currentTime->setTime((int) $currentTime->format('H'), (int) $currentTime->format('i'), 0);
 
         try {
             return $this->getNextRunDate($currentTime, 0, true)->getTimestamp() === $currentTime->getTimestamp();

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -377,7 +377,7 @@ class CronExpression
             $dowRunDates = $dowExpression->getMultipleRunDates($nth + 1, $currentTime, $invert, $allowCurrentDate, $timeZone);
 
             $combined = array_merge($domRunDates, $dowRunDates);
-            usort($combined, function($a, $b) {
+            usort($combined, function ($a, $b) {
                 return $a->format('Y-m-d H:i:s') <=> $b->format('Y-m-d H:i:s');
             });
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -421,7 +421,7 @@ class CronExpression
             return $timeZone;
         }
 
-        if ($currentTime instanceOf DateTimeInterface) {
+        if ($currentTime instanceof DateTimeInterface) {
             return $currentTime->getTimeZone()->getName();
         }
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -39,7 +39,7 @@ class CronExpression
     private $cronParts;
 
     /**
-     * @var FieldFactory CRON field factory
+     * @var FieldFactoryInterface CRON field factory
      */
     private $fieldFactory;
 
@@ -65,11 +65,11 @@ class CronExpression
      *      `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
      *      `@daily` - Run once a day, midnight - 0 0 * * *
      *      `@hourly` - Run once an hour, first minute - 0 * * * *
-     * @param null|FieldFactory $fieldFactory Field factory to use
+     * @param null|FieldFactoryInterface $fieldFactory Field factory to use
      *
      * @return CronExpression
      */
-    public static function factory(string $expression, FieldFactory $fieldFactory = null): CronExpression
+    public static function factory(string $expression, FieldFactoryInterface $fieldFactory = null): CronExpression
     {
         $mappings = [
             '@yearly' => '0 0 1 1 *',

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -189,6 +189,30 @@ class CronExpression
     }
 
     /**
+     * @param string $value
+     * @return bool TRUE if the expression is valid
+     */
+    public static function isValid(string $value) : bool {
+        $split = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        if (!is_array($split)) return FALSE;
+
+        $notEnoughParts = \count($split) < 5;
+
+        $questionMarkInInvalidPart = array_key_exists(0, $split) && $split[0] === '?'
+            || array_key_exists(1, $split) && $split[1] === '?'
+            || array_key_exists(3, $split) && $split[3] === '?';
+
+        $tooManyQuestionMarks = array_key_exists(2, $split) && $split[2] === '?'
+            && array_key_exists(4, $split) && $split[4] === '?';
+
+        if ($notEnoughParts || $questionMarkInInvalidPart || $tooManyQuestionMarks) {
+            return FALSE;
+        }
+
+        return TRUE;
+    }
+
+    /**
      * Set or change the CRON expression.
      *
      * @param string $value CRON expression (e.g. 8 * * * *)
@@ -202,16 +226,7 @@ class CronExpression
         $split = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
         Assert::isArray($split);
 
-        $notEnoughParts = \count($split) < 5;
-
-        $questionMarkInInvalidPart = array_key_exists(0, $split) && $split[0] === '?'
-            || array_key_exists(1, $split) && $split[1] === '?'
-            || array_key_exists(3, $split) && $split[3] === '?';
-
-        $tooManyQuestionMarks = array_key_exists(2, $split) && $split[2] === '?'
-            && array_key_exists(4, $split) && $split[4] === '?';
-
-        if ($notEnoughParts || $questionMarkInInvalidPart || $tooManyQuestionMarks) {
+        if (!self::isValid($value)) {
             throw new InvalidArgumentException(
                 $value . ' is not a valid CRON expression'
             );

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -179,16 +179,17 @@ class CronExpression
     /**
      * Get a next run date relative to the current date or a specific date
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning a
-     *                                           matching next run date.  0, the default, will return the current
-     *                                           date and time if the next run date falls on the current date and
-     *                                           time.  Setting this value to 1 will skip the first match and go to
-     *                                           the second match.  Setting this value to 2 will skip the first 2
-     *                                           matches and so on.
-     * @param bool             $allowCurrentDate Set to TRUE to return the current date if
-     *                                           it matches the cron expression.
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param int                       $nth              Number of matches to skip before returning a
+     *                                                    matching next run date.  0, the default, will return the
+     *                                                    current date and time if the next run date falls on the
+     *                                                    current date and time.  Setting this value to 1 will
+     *                                                    skip the first match and go to the second match.
+     *                                                    Setting this value to 2 will skip the first 2
+     *                                                    matches and so on.
+     * @param bool                      $allowCurrentDate Set to TRUE to return the current date if
+     *                                                    it matches the cron expression.
+     * @param null|string               $timeZone         TimeZone to use instead of the system default
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
@@ -201,11 +202,11 @@ class CronExpression
     /**
      * Get a previous run date relative to the current date or a specific date
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param int                       $nth              Number of matches to skip before returning
+     * @param bool                      $allowCurrentDate Set to TRUE to return the
+     *                                                    current date if it matches the cron expression
+     * @param null|string               $timeZone         TimeZone to use instead of the system default
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations
@@ -219,14 +220,14 @@ class CronExpression
     /**
      * Get multiple run dates starting at the current date or a specific date
      *
-     * @param int              $total            Set the total number of dates to calculate
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param bool             $invert           Set to TRUE to retrieve previous dates
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param null|string      $timeZone         TimeZone to use instead of the system default
+     * @param int                       $total            Set the total number of dates to calculate
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param bool                      $invert           Set to TRUE to retrieve previous dates
+     * @param bool                      $allowCurrentDate Set to TRUE to return the
+     *                                                    current date if it matches the cron expression
+     * @param null|string               $timeZone         TimeZone to use instead of the system default
      *
-     * @return array Returns an array of run dates
+     * @return \DateTime[] Returns an array of run dates
      */
     public function getMultipleRunDates($total, $currentTime = 'now', $invert = false, $allowCurrentDate = false, $timeZone = null)
     {
@@ -277,8 +278,8 @@ class CronExpression
      * specific date.  This method assumes that the current number of
      * seconds are irrelevant, and should be called once per minute.
      *
-     * @param string|\DateTime $currentTime Relative calculation date
-     * @param null|string      $timeZone    TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime Relative calculation date
+     * @param null|string               $timeZone    TimeZone to use instead of the system default
      *
      * @return bool Returns TRUE if the cron is due to run or FALSE if not
      */
@@ -310,12 +311,12 @@ class CronExpression
     /**
      * Get the next or previous run date of the expression relative to a date
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param int              $nth              Number of matches to skip before returning
-     * @param bool             $invert           Set to TRUE to go backwards in time
-     * @param bool             $allowCurrentDate Set to TRUE to return the
-     *                                           current date if it matches the cron expression
-     * @param string|null      $timeZone         TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param int                       $nth              Number of matches to skip before returning
+     * @param bool                      $invert           Set to TRUE to go backwards in time
+     * @param bool                      $allowCurrentDate Set to TRUE to return the
+     *                                                    current date if it matches the cron expression
+     * @param string|null               $timeZone         TimeZone to use instead of the system default
      *
      * @return \DateTime
      * @throws \RuntimeException on too many iterations

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -4,6 +4,7 @@ namespace Cron;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
@@ -391,8 +392,8 @@ class CronExpression
     /**
      * Workout what timeZone should be used.
      *
-     * @param string|\DateTime $currentTime      Relative calculation date
-     * @param string|null      $timeZone         TimeZone to use instead of the system default
+     * @param string|\DateTimeInterface $currentTime      Relative calculation date
+     * @param string|null               $timeZone         TimeZone to use instead of the system default
      *
      * @return string
      */
@@ -402,7 +403,7 @@ class CronExpression
             return $timeZone;
         }
 
-        if ($currentTime instanceOf Datetime) {
+        if ($currentTime instanceOf DateTimeInterface) {
             return $currentTime->getTimeZone()->getName();
         }
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -268,6 +268,17 @@ class CronExpression
     }
 
     /**
+     * Gets the parts of the cron expression as an array.
+     *
+     * @return string[]
+     *   The array of parts that make up this expression.
+     */
+    public function getParts()
+    {
+        return $this->cronParts;
+    }
+
+    /**
      * Helper method to output the full expression.
      *
      * @return string Full CRON expression

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -32,6 +32,8 @@ class CronExpression
     public const DAY = 2;
     public const MONTH = 3;
     public const WEEKDAY = 4;
+    
+    /** @deprecated */
     public const YEAR = 5;
 
     public const MAPPINGS = [

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -365,6 +365,24 @@ class CronExpression
             $fields[$position] = $this->fieldFactory->getField($position);
         }
 
+        if (isset($parts[2]) && isset($parts[4])) {
+            $domExpression = sprintf('%s %s %s %s *', $this->getExpression(0), $this->getExpression(1), $this->getExpression(2), $this->getExpression(3));
+            $dowExpression = sprintf('%s %s * %s %s', $this->getExpression(0), $this->getExpression(1), $this->getExpression(3), $this->getExpression(4));
+
+            $domExpression = new self($domExpression);
+            $dowExpression = new self($dowExpression);
+
+            $domRunDates = $domExpression->getMultipleRunDates($nth + 1, $currentTime, $invert, $allowCurrentDate, $timeZone);
+            $dowRunDates = $dowExpression->getMultipleRunDates($nth + 1, $currentTime, $invert, $allowCurrentDate, $timeZone);
+
+            $combined = array_merge($domRunDates, $dowRunDates);
+            usort($combined, function($a, $b) {
+                return $a->format('Y-m-d H:i:s') <=> $b->format('Y-m-d H:i:s');
+            });
+
+            return $combined[$nth];
+        }
+
         // Set a hard limit to bail on an impossible date
         for ($i = 0; $i < $this->maxIterationCount; ++$i) {
             foreach ($parts as $position => $part) {

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -240,10 +240,10 @@ class CronExpression
     public function getMultipleRunDates(int $total, $currentTime = 'now', bool $invert = false, bool $allowCurrentDate = false, $timeZone = null): array
     {
         $matches = [];
-        $max = max(0, $total);
-        for ($i = 0; $i < $max; ++$i) {
+        for ($i = 0; $i < $total; ++$i) {
             try {
-                $matches[] = $this->getRunDate($currentTime, $i, $invert, $allowCurrentDate, $timeZone);
+                $currentTime = $this->getRunDate($currentTime, 0, $invert, $i === 0 ? $allowCurrentDate : false, $timeZone);
+                $matches[] = $currentTime;
             } catch (RuntimeException $e) {
                 break;
             }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -75,6 +75,7 @@ class CronExpression
      */
     public static function factory(string $expression, FieldFactoryInterface $fieldFactory = null): CronExpression
     {
+        /** @phpstan-ignore-next-line */
         return new static($expression, $fieldFactory);
     }
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -406,6 +406,6 @@ class CronExpression
             return $currentTime->getTimeZone()->getName();
         }
 
-        return date_default_timeZone_get();
+        return date_default_timezone_get();
     }
 }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -80,8 +80,9 @@ class CronExpression
             '@hourly' => '0 * * * *',
         ];
 
-        if (isset($mappings[$expression])) {
-            $expression = $mappings[$expression];
+        $shortcut = strtolower($expression);
+        if (isset($mappings[$shortcut])) {
+            $expression = $mappings[$shortcut];
         }
 
         return new static($expression, $fieldFactory ?: new FieldFactory());

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -85,7 +85,7 @@ class CronExpression
             $expression = $mappings[$shortcut];
         }
 
-        return new static($expression, $fieldFactory ?: new FieldFactory());
+        return new static($expression, $fieldFactory);
     }
 
     /**
@@ -112,9 +112,9 @@ class CronExpression
      * Parse a CRON expression.
      *
      * @param string $expression CRON expression (e.g. '8 * * * *')
-     * @param null|FieldFactory $fieldFactory Factory to create cron fields
+     * @param null|FieldFactoryInterface $fieldFactory Factory to create cron fields
      */
-    public function __construct(string $expression, FieldFactory $fieldFactory = null)
+    public function __construct(string $expression, FieldFactoryInterface $fieldFactory = null)
     {
         $this->fieldFactory = $fieldFactory ?: new FieldFactory();
         $this->setExpression($expression);

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -62,7 +62,7 @@ class CronExpression
      *      `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
      *      `@daily` - Run once a day, midnight - 0 0 * * *
      *      `@hourly` - Run once an hour, first minute - 0 * * * *
-     * @param FieldFactory $fieldFactory Field factory to use
+     * @param FieldFactory|null $fieldFactory Field factory to use
      *
      * @return CronExpression
      */
@@ -107,9 +107,9 @@ class CronExpression
      * Parse a CRON expression
      *
      * @param string       $expression   CRON expression (e.g. '8 * * * *')
-     * @param FieldFactory $fieldFactory Factory to create cron fields
+     * @param FieldFactory|null $fieldFactory Factory to create cron fields
      */
-    public function __construct($expression, FieldFactory $fieldFactory)
+    public function __construct($expression, FieldFactory $fieldFactory = null)
     {
         $this->fieldFactory = $fieldFactory;
         $this->setExpression($expression);

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -303,7 +303,7 @@ class CronExpression
         if ('now' === $currentTime) {
             $currentTime = new DateTime();
         } elseif ($currentTime instanceof DateTime) {
-            //
+            $currentTime = clone $currentTime;
         } elseif ($currentTime instanceof DateTimeImmutable) {
             $currentTime = DateTime::createFromFormat('U', $currentTime->format('U'));
         } else {

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -33,6 +33,15 @@ class CronExpression
     public const WEEKDAY = 4;
     public const YEAR = 5;
 
+    public const MAPPINGS = [
+        '@yearly' => '0 0 1 1 *',
+        '@annually' => '0 0 1 1 *',
+        '@monthly' => '0 0 1 * *',
+        '@weekly' => '0 0 * * 0',
+        '@daily' => '0 0 * * *',
+        '@hourly' => '0 * * * *',
+    ];
+
     /**
      * @var array CRON expression parts
      */
@@ -51,40 +60,20 @@ class CronExpression
     /**
      * @var array Order in which to test of cron parts
      */
-    private static $order = [self::YEAR, self::MONTH, self::DAY, self::WEEKDAY, self::HOUR, self::MINUTE];
+    private static $order = [
+        self::YEAR,
+        self::MONTH,
+        self::DAY,
+        self::WEEKDAY,
+        self::HOUR,
+        self::MINUTE,
+    ];
 
     /**
-     * Factory method to create a new CronExpression.
-     *
-     * @param string $expression The CRON expression to create.  There are
-     *                           several special predefined values which can be used to substitute the
-     *                           CRON expression:
-     *
-     *      `@yearly`, `@annually` - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
-     *      `@monthly` - Run once a month, midnight, first of month - 0 0 1 * *
-     *      `@weekly` - Run once a week, midnight on Sun - 0 0 * * 0
-     *      `@daily` - Run once a day, midnight - 0 0 * * *
-     *      `@hourly` - Run once an hour, first minute - 0 * * * *
-     * @param null|FieldFactoryInterface $fieldFactory Field factory to use
-     *
-     * @return CronExpression
+     * @deprecated since version 3.0.2, use __construct instead.
      */
     public static function factory(string $expression, FieldFactoryInterface $fieldFactory = null): CronExpression
     {
-        $mappings = [
-            '@yearly' => '0 0 1 1 *',
-            '@annually' => '0 0 1 1 *',
-            '@monthly' => '0 0 1 * *',
-            '@weekly' => '0 0 * * 0',
-            '@daily' => '0 0 * * *',
-            '@hourly' => '0 * * * *',
-        ];
-
-        $shortcut = strtolower($expression);
-        if (isset($mappings[$shortcut])) {
-            $expression = $mappings[$shortcut];
-        }
-
         return new static($expression, $fieldFactory);
     }
 
@@ -94,13 +83,11 @@ class CronExpression
      * @param string $expression the CRON expression to validate
      *
      * @return bool True if a valid CRON expression was passed. False if not.
-     *
-     * @see \Cron\CronExpression::factory
      */
     public static function isValidExpression(string $expression): bool
     {
         try {
-            self::factory($expression);
+            new CronExpression($expression);
         } catch (InvalidArgumentException $e) {
             return false;
         }
@@ -116,6 +103,9 @@ class CronExpression
      */
     public function __construct(string $expression, FieldFactoryInterface $fieldFactory = null)
     {
+        $shortcut = strtolower($expression);
+        $expression = self::MAPPINGS[$shortcut] ?? $expression;
+
         $this->fieldFactory = $fieldFactory ?: new FieldFactory();
         $this->setExpression($expression);
     }

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -115,7 +115,7 @@ class CronExpression
      */
     public function __construct(string $expression, FieldFactory $fieldFactory = null)
     {
-        $this->fieldFactory = $fieldFactory;
+        $this->fieldFactory = $fieldFactory ?: new FieldFactory();
         $this->setExpression($expression);
     }
 

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -410,6 +410,14 @@ class CronExpression
             $domRunDates = $domExpression->getMultipleRunDates($nth + 1, $currentTime, $invert, $allowCurrentDate, $timeZone);
             $dowRunDates = $dowExpression->getMultipleRunDates($nth + 1, $currentTime, $invert, $allowCurrentDate, $timeZone);
 
+            if ($parts[self::DAY] === '?' || $parts[self::DAY] === '*') {
+                $domRunDates = [];
+            }
+
+            if ($parts[self::WEEKDAY] === '?' || $parts[self::WEEKDAY] === '*') {
+                $dowRunDates = [];
+            }
+
             $combined = array_merge($domRunDates, $dowRunDates);
             usort($combined, function ($a, $b) {
                 return $a->format('Y-m-d H:i:s') <=> $b->format('Y-m-d H:i:s');

--- a/src/Cron/CronExpression.php
+++ b/src/Cron/CronExpression.php
@@ -456,6 +456,9 @@ class CronExpression
         $currentDate->setTimezone(new DateTimeZone($timeZone));
         // Workaround for setTime causing an offset change: https://bugs.php.net/bug.php?id=81074
         $currentDate = DateTime::createFromFormat("!Y-m-d H:iO", $currentDate->format("Y-m-d H:iP"), $currentDate->getTimezone());
+        if ($currentDate === false) {
+            throw new \RuntimeException('Unable to create date from format');
+        }
         $currentDate->setTimezone(new DateTimeZone($timeZone));
 
         $nextRun = clone $currentDate;

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -96,15 +96,18 @@ class DayOfMonthField extends AbstractField
         // Check to see if this is the nearest weekday to a particular value
         if (strpos($value, 'W')) {
             // Parse the target day
-            /** @phpstan-ignore-next-line */
             $targetDay = (int) substr($value, 0, strpos($value, 'W'));
             // Find out if the current day is the nearest day of the week
-            /** @phpstan-ignore-next-line */
-            return $date->format('j') === self::getNearestWeekday(
+            $nearest = self::getNearestWeekday(
                 (int) $date->format('Y'),
                 (int) $date->format('m'),
                 $targetDay
-            )->format('j');
+            );
+            if ($nearest) {
+                return $date->format('j') === $nearest->format('j');
+            }
+
+            throw new \RuntimeException('Unable to return nearest weekday');
         }
 
         return $this->isSatisfied((int) $date->format('d'), $value);

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -79,7 +79,7 @@ class DayOfMonthField extends AbstractField
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTimeInterface $date, $value): bool
+    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert): bool
     {
         // ? states that the field value is to be skipped
         if ('?' === $value) {
@@ -117,10 +117,12 @@ class DayOfMonthField extends AbstractField
      */
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
-        if ($invert) {
-            $date = $date->modify('previous day')->setTime(23, 59);
+        if (! $invert) {
+            $date = $this->timezoneSafeModify($date, '+1 day');
+            $date = $date->setTime(0, 0);
         } else {
-            $date = $date->modify('next day')->setTime(0, 0);
+            $date = $this->timezoneSafeModify($date, '-1 day');
+            $date = $date->setTime(23, 59);
         }
 
         return $this;

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -49,7 +49,7 @@ class DayOfMonthField extends AbstractField
     private static function getNearestWeekday(int $currentYear, int $currentMonth, int $targetDay): ?DateTime
     {
         $tday = str_pad((string) $targetDay, 2, '0', STR_PAD_LEFT);
-        $target = DateTime::createFromFormat('Y-m-d', "${currentYear}-${currentMonth}-${tday}");
+        $target = DateTime::createFromFormat('Y-m-d', "{$currentYear}-{$currentMonth}-{$tday}");
 
         if ($target === false) {
             return null;

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -118,10 +118,10 @@ class DayOfMonthField extends AbstractField
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
         if (! $invert) {
-            $date = $this->timezoneSafeModify($date, '+1 day');
+            $date = $date->add(new \DateInterval('P1D'));
             $date = $date->setTime(0, 0);
         } else {
-            $date = $this->timezoneSafeModify($date, '-1 day');
+            $date = $date->sub(new \DateInterval('P1D'));
             $date = $date->setTime(23, 59);
         }
 

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -94,9 +94,9 @@ class DayOfMonthField extends AbstractField
         }
 
         // Check to see if this is the nearest weekday to a particular value
-        if (strpos($value, 'W')) {
+        if ($wPosition = strpos($value, 'W')) {
             // Parse the target day
-            $targetDay = (int) substr($value, 0, strpos($value, 'W'));
+            $targetDay = (int) substr($value, 0, $wPosition);
             // Find out if the current day is the nearest day of the week
             $nearest = self::getNearestWeekday(
                 (int) $date->format('Y'),

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -3,6 +3,7 @@
 namespace Cron;
 
 use DateTime;
+use DateTimeInterface;
 
 /**
  * Day of month field.  Allows: * , / - ? L W
@@ -69,7 +70,7 @@ class DayOfMonthField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
         // ? states that the field value is to be skipped
         if ($value == '?') {
@@ -100,15 +101,15 @@ class DayOfMonthField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable &$date
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTimeInterface &$date, $invert = false)
     {
         if ($invert) {
-            $date->modify('previous day');
-            $date->setTime(23, 59);
+            $date = $date->modify('previous day')->setTime(23, 59);
         } else {
-            $date->modify('next day');
-            $date->setTime(0, 0);
+            $date = $date->modify('next day')->setTime(0, 0);
         }
 
         return $this;

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -130,6 +130,10 @@ class DayOfMonthField extends AbstractField
         }
 
         if (!$basicChecks) {
+            if ('?' === $value) {
+                return true;
+            }
+
             if ('L' === $value) {
                 return true;
             }

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -6,7 +6,6 @@ namespace Cron;
 
 use DateTime;
 use DateTimeInterface;
-use Webmozart\Assert\Assert;
 
 /**
  * Day of month field.  Allows: * , / - ? L W.

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use DateTime;
 
 /**
- * Day of month field.  Allows: * , / - ? L W
+ * Day of month field.  Allows: * , / - ? L W.
  *
  * 'L' stands for "last" and specifies the last day of the month.
  *
@@ -25,28 +27,28 @@ use DateTime;
 class DayOfMonthField extends AbstractField
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeStart = 1;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeEnd = 31;
 
     /**
-     * Get the nearest day of the week for a given day in a month
+     * Get the nearest day of the week for a given day in a month.
      *
-     * @param int $currentYear  Current year
+     * @param int $currentYear Current year
      * @param int $currentMonth Current month
-     * @param int $targetDay    Target day of the month
+     * @param int $targetDay Target day of the month
      *
      * @return \DateTime Returns the nearest date
      */
-    private static function getNearestWeekday($currentYear, $currentMonth, $targetDay)
+    private static function getNearestWeekday(int $currentYear, int $currentMonth, int $targetDay): ?DateTime
     {
-        $tday = str_pad($targetDay, 2, '0', STR_PAD_LEFT);
-        $target = DateTime::createFromFormat('Y-m-d', "$currentYear-$currentMonth-$tday");
+        $tday = str_pad((string) $targetDay, 2, '0', STR_PAD_LEFT);
+        $target = DateTime::createFromFormat('Y-m-d', "${currentYear}-${currentMonth}-${tday}");
         $currentWeekday = (int) $target->format('N');
 
         if ($currentWeekday < 6) {
@@ -54,12 +56,12 @@ class DayOfMonthField extends AbstractField
         }
 
         $lastDayOfMonth = $target->format('t');
-
-        foreach (array(-1, 1, -2, 2) as $i) {
+        foreach ([-1, 1, -2, 2] as $i) {
             $adjusted = $targetDay + $i;
             if ($adjusted > 0 && $adjusted <= $lastDayOfMonth) {
                 $target->setDate($currentYear, $currentMonth, $adjusted);
-                if ($target->format('N') < 6 && $target->format('m') == $currentMonth) {
+
+                if ((int) $target->format('N') < 6 && (int) $target->format('m') === $currentMonth) {
                     return $target;
                 }
             }
@@ -67,41 +69,41 @@ class DayOfMonthField extends AbstractField
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, string $value): bool
     {
         // ? states that the field value is to be skipped
-        if ($value == '?') {
+        if ('?' === $value) {
             return true;
         }
 
         $fieldValue = $date->format('d');
 
         // Check to see if this is the last day of the month
-        if ($value == 'L') {
-            return $fieldValue == $date->format('t');
+        if ('L' === $value) {
+            return $fieldValue === $date->format('t');
         }
 
         // Check to see if this is the nearest weekday to a particular value
         if (strpos($value, 'W')) {
             // Parse the target day
-            $targetDay = substr($value, 0, strpos($value, 'W'));
+            $targetDay = (int) substr($value, 0, strpos($value, 'W'));
             // Find out if the current day is the nearest day of the week
-            return $date->format('j') == self::getNearestWeekday(
-                $date->format('Y'),
-                $date->format('m'),
+            return $date->format('j') === self::getNearestWeekday(
+                    (int) $date->format('Y'),
+                    (int) $date->format('m'),
                 $targetDay
             )->format('j');
         }
 
-        return $this->isSatisfied($date->format('d'), $value);
+        return $this->isSatisfied((int) $date->format('d'), $value);
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTime $date, bool $invert = false, ?string $parts = null): FieldInterface
     {
         if ($invert) {
             $date->modify('previous day');
@@ -115,20 +117,19 @@ class DayOfMonthField extends AbstractField
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function validate($value)
+    public function validate(string $value): bool
     {
         $basicChecks = parent::validate($value);
 
         // Validate that a list don't have W or L
-        if (strpos($value, ',') !== false && (strpos($value, 'W') !== false || strpos($value, 'L') !== false)) {
+        if (false !== strpos($value, ',') && (false !== strpos($value, 'W') || false !== strpos($value, 'L'))) {
             return false;
         }
 
         if (!$basicChecks) {
-
-            if ($value === 'L') {
+            if ('L' === $value) {
                 return true;
             }
 

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -24,7 +24,14 @@ use DateTime;
  */
 class DayOfMonthField extends AbstractField
 {
+    /**
+     * @inheritDoc
+     */
     protected $rangeStart = 1;
+
+    /**
+     * @inheritDoc
+     */
     protected $rangeEnd = 31;
 
     /**

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -102,8 +102,8 @@ class DayOfMonthField extends AbstractField
             // Find out if the current day is the nearest day of the week
             /** @phpstan-ignore-next-line */
             return $date->format('j') === self::getNearestWeekday(
-                    (int) $date->format('Y'),
-                    (int) $date->format('m'),
+                (int) $date->format('Y'),
+                (int) $date->format('m'),
                 $targetDay
             )->format('j');
         }

--- a/src/Cron/DayOfMonthField.php
+++ b/src/Cron/DayOfMonthField.php
@@ -59,6 +59,9 @@ class DayOfMonthField extends AbstractField
         }
     }
 
+    /**
+     * @inheritDoc
+     */
     public function isSatisfiedBy(DateTime $date, $value)
     {
         // ? states that the field value is to be skipped
@@ -88,6 +91,9 @@ class DayOfMonthField extends AbstractField
         return $this->isSatisfied($date->format('d'), $value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -68,8 +68,8 @@ class DayOfWeekField extends AbstractField
         $lastDayOfMonth = (int) $date->format('t');
 
         // Find out if this is the last specific weekday of the month
-        if (strpos($value, 'L')) {
-            $weekday = $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
+        if ($lPosition = strpos($value, 'L')) {
+            $weekday = $this->convertLiterals(substr($value, 0, $lPosition));
             $weekday %= 7;
 
             $daysInMonth = (int) $date->format('t');

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -69,7 +69,6 @@ class DayOfWeekField extends AbstractField
 
         // Find out if this is the last specific weekday of the month
         if (strpos($value, 'L')) {
-            /** @phpstan-ignore-next-line */
             $weekday = $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
             $weekday %= 7;
 

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Cron;
 
-use DateTime;
 use DateTimeInterface;
 use InvalidArgumentException;
 
@@ -54,10 +53,8 @@ class DayOfWeekField extends AbstractField
 
     /**
      * @inheritDoc
-     *
-     * @param \DateTime|\DateTimeImmutable $date
      */
-    public function isSatisfiedBy(DateTimeInterface $date, $value): bool
+    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert): bool
     {
         if ('?' === $value) {
             return true;
@@ -76,15 +73,9 @@ class DayOfWeekField extends AbstractField
             $weekday = $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
             $weekday %= 7;
 
-            $tdate = clone $date;
-            $tdate = $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
-            while ($tdate->format('w') != $weekday) {
-                $tdateClone = new DateTime();
-                $tdate = $tdateClone->setTimezone($tdate->getTimezone())
-                    ->setDate($currentYear, $currentMonth, --$lastDayOfMonth);
-            }
-
-            return (int) $date->format('j') === $lastDayOfMonth;
+            $daysInMonth = (int) $date->format('t');
+            $remainingDaysInMonth = $daysInMonth - (int) $date->format('d');
+            return (($weekday === (int) $date->format('w')) && ($remainingDaysInMonth < 7));
         }
 
         // Handle # hash tokens
@@ -156,15 +147,15 @@ class DayOfWeekField extends AbstractField
 
     /**
      * @inheritDoc
-     *
-     * @param \DateTime|\DateTimeImmutable $date
      */
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
-        if ($invert) {
-            $date = $date->modify('-1 day')->setTime(23, 59, 0);
+        if (! $invert) {
+            $date = $this->timezoneSafeModify($date, '+1 day');
+            $date = $date->setTime(0, 0);
         } else {
-            $date = $date->modify('+1 day')->setTime(0, 0, 0);
+            $date = $this->timezoneSafeModify($date, '-1 day');
+            $date = $date->setTime(23, 59);
         }
 
         return $this;

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -73,7 +73,7 @@ class DayOfWeekField extends AbstractField
         // Find out if this is the last specific weekday of the month
         if (strpos($value, 'L')) {
             $weekday = (int) $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
-            $weekday = (int) str_replace(7, 0, $weekday);
+            $weekday %= 7;
 
             $tdate = clone $date;
             $tdate = $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -151,10 +151,10 @@ class DayOfWeekField extends AbstractField
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
         if (! $invert) {
-            $date = $this->timezoneSafeModify($date, '+1 day');
+            $date = $date->add(new \DateInterval('P1D'));
             $date = $date->setTime(0, 0);
         } else {
-            $date = $this->timezoneSafeModify($date, '-1 day');
+            $date = $date->sub(new \DateInterval('P1D'));
             $date = $date->setTime(23, 59);
         }
 

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -72,7 +72,8 @@ class DayOfWeekField extends AbstractField
 
         // Find out if this is the last specific weekday of the month
         if (strpos($value, 'L')) {
-            $weekday = (int) $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
+            /** @phpstan-ignore-next-line */
+            $weekday = $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
             $weekday %= 7;
 
             $tdate = clone $date;
@@ -157,9 +158,9 @@ class DayOfWeekField extends AbstractField
     /**
      * @inheritDoc
      *
-     * @param \DateTime|\DateTimeImmutable &$date
+     * @param \DateTime|\DateTimeImmutable $date
      */
-    public function increment(DateTimeInterface &$date, $invert = false): FieldInterface
+    public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
         if ($invert) {
             $date = $date->modify('-1 day')->setTime(23, 59, 0);

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -28,12 +28,18 @@ class DayOfWeekField extends AbstractField
 
     protected $literals = [1 => 'MON', 2 => 'TUE', 3 => 'WED', 4 => 'THU', 5 => 'FRI', 6 => 'SAT', 7 => 'SUN'];
 
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->nthRange = range(1, 5);
         parent::__construct();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function isSatisfiedBy(DateTime $date, $value)
     {
         if ($value == '?') {
@@ -129,6 +135,9 @@ class DayOfWeekField extends AbstractField
         return $this->isSatisfied($fieldValue, $value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -178,6 +178,10 @@ class DayOfWeekField extends AbstractField
         $basicChecks = parent::validate($value);
 
         if (!$basicChecks) {
+            if ('?' === $value) {
+                return true;
+            }
+
             // Handle the # value
             if (false !== strpos($value, '#')) {
                 $chunks = explode('#', $value);

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -80,8 +80,7 @@ class DayOfWeekField extends AbstractField
             $tdate = $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
             while ($tdate->format('w') != $weekday) {
                 $tdateClone = new DateTime();
-                $tdate = $tdateClone
-                    ->setTimezone($tdate->getTimezone())
+                $tdate = $tdateClone->setTimezone($tdate->getTimezone())
                     ->setDate($currentYear, $currentMonth, --$lastDayOfMonth);
             }
 

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -5,7 +5,6 @@ namespace Cron;
 use DateTime;
 use InvalidArgumentException;
 
-
 /**
  * Day of week field.  Allows: * / , - ? L #
  *

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use DateTime;
 use InvalidArgumentException;
 
 /**
- * Day of week field.  Allows: * / , - ? L #
+ * Day of week field.  Allows: * / , - ? L #.
  *
  * Days of the week can be represented as a number 0-7 (0|7 = Sunday)
  * or as a three letter string: SUN, MON, TUE, WED, THU, FRI, SAT.
@@ -21,12 +23,12 @@ use InvalidArgumentException;
 class DayOfWeekField extends AbstractField
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeStart = 0;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeEnd = 7;
 
@@ -36,12 +38,12 @@ class DayOfWeekField extends AbstractField
     protected $nthRange;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $literals = [1 => 'MON', 2 => 'TUE', 3 => 'WED', 4 => 'THU', 5 => 'FRI', 6 => 'SAT', 7 => 'SUN'];
 
     /**
-     * Constructor
+     * Constructor.
      */
     public function __construct()
     {
@@ -50,41 +52,42 @@ class DayOfWeekField extends AbstractField
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, string $value): bool
     {
-        if ($value == '?') {
+        if ('?' === $value) {
             return true;
         }
 
         // Convert text day of the week values to integers
         $value = $this->convertLiterals($value);
 
-        $currentYear = $date->format('Y');
-        $currentMonth = $date->format('m');
-        $lastDayOfMonth = $date->format('t');
+        $currentYear = (int) $date->format('Y');
+        $currentMonth = (int) $date->format('m');
+        $lastDayOfMonth = (int) $date->format('t');
 
         // Find out if this is the last specific weekday of the month
         if (strpos($value, 'L')) {
-            $weekday = $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
-            $weekday = str_replace('7', '0', $weekday);
+            $weekday = (int) $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
+            $weekday = (int) str_replace(7, 0, $weekday);
 
             $tdate = clone $date;
             $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
-            while ($tdate->format('w') != $weekday) {
+
+            while ((int) $tdate->format('w') !== $weekday) {
                 $tdateClone = new DateTime();
                 $tdate = $tdateClone
                     ->setTimezone($tdate->getTimezone())
                     ->setDate($currentYear, $currentMonth, --$lastDayOfMonth);
             }
 
-            return $date->format('j') == $lastDayOfMonth;
+            return (int) $date->format('j') === $lastDayOfMonth;
         }
 
         // Handle # hash tokens
         if (strpos($value, '#')) {
-            list($weekday, $nth) = explode('#', $value);
+            [$weekday, $nth] = explode('#', $value);
 
             if (!is_numeric($nth)) {
                 throw new InvalidArgumentException("Hashed weekdays must be numeric, {$nth} given");
@@ -93,23 +96,23 @@ class DayOfWeekField extends AbstractField
             }
 
             // 0 and 7 are both Sunday, however 7 matches date('N') format ISO-8601
-            if ($weekday === '0') {
+            if ('0' === $weekday) {
                 $weekday = 7;
             }
 
-            $weekday = $this->convertLiterals($weekday);
+            $weekday = (int) $this->convertLiterals((string) $weekday);
 
             // Validate the hash fields
             if ($weekday < 0 || $weekday > 7) {
                 throw new InvalidArgumentException("Weekday must be a value between 0 and 7. {$weekday} given");
             }
 
-            if (!in_array($nth, $this->nthRange)) {
+            if (!\in_array($nth, $this->nthRange, true)) {
                 throw new InvalidArgumentException("There are never more than 5 or less than 1 of a given weekday in a month, {$nth} given");
             }
 
             // The current weekday must match the targeted weekday to proceed
-            if ($date->format('N') != $weekday) {
+            if ((int) $date->format('N') !== $weekday) {
                 return false;
             }
 
@@ -118,7 +121,7 @@ class DayOfWeekField extends AbstractField
             $dayCount = 0;
             $currentDay = 1;
             while ($currentDay < $lastDayOfMonth + 1) {
-                if ($tdate->format('N') == $weekday) {
+                if ((int) $tdate->format('N') === $weekday) {
                     if (++$dayCount >= $nth) {
                         break;
                     }
@@ -126,31 +129,33 @@ class DayOfWeekField extends AbstractField
                 $tdate->setDate($currentYear, $currentMonth, ++$currentDay);
             }
 
-            return $date->format('j') == $currentDay;
+            return (int) $date->format('j') === $currentDay;
         }
 
         // Handle day of the week values
-        if (strpos($value, '-')) {
+        if (false !== strpos($value, '-')) {
             $parts = explode('-', $value);
-            if ($parts[0] == '7') {
-                $parts[0] = '0';
-            } elseif ($parts[1] == '0') {
-                $parts[1] = '7';
+            if ('7' === $parts[0]) {
+                $parts[0] = 0;
+            } elseif ('0' === $parts[1]) {
+                $parts[1] = 7;
             }
             $value = implode('-', $parts);
         }
 
         // Test to see which Sunday to use -- 0 == 7 == Sunday
-        $format = in_array(7, str_split($value)) ? 'N' : 'w';
-        $fieldValue = $date->format($format);
+        $format = \in_array(7, array_map(function ($value) {
+            return (int) $value;
+        }, str_split($value)), true) ? 'N' : 'w';
+        $fieldValue = (int) $date->format($format);
 
         return $this->isSatisfied($fieldValue, $value);
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTime $date, bool $invert = false, ?string $parts = null): FieldInterface
     {
         if ($invert) {
             $date->modify('-1 day');
@@ -164,19 +169,19 @@ class DayOfWeekField extends AbstractField
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function validate($value)
+    public function validate(string $value): bool
     {
         $basicChecks = parent::validate($value);
 
         if (!$basicChecks) {
             // Handle the # value
-            if (strpos($value, '#') !== false) {
+            if (false !== strpos($value, '#')) {
                 $chunks = explode('#', $value);
                 $chunks[0] = $this->convertLiterals($chunks[0]);
 
-                if (parent::validate($chunks[0]) && is_numeric($chunks[1]) && in_array($chunks[1], $this->nthRange)) {
+                if (parent::validate($chunks[0]) && is_numeric($chunks[1]) && \in_array((int) $chunks[1], $this->nthRange, true)) {
                     return true;
                 }
             }

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -21,11 +21,24 @@ use InvalidArgumentException;
  */
 class DayOfWeekField extends AbstractField
 {
+    /**
+     * @inheritDoc
+     */
     protected $rangeStart = 0;
+
+    /**
+     * @inheritDoc
+     */
     protected $rangeEnd = 7;
 
+    /**
+     * @var array Weekday range
+     */
     protected $nthRange;
 
+    /**
+     * @inheritDoc
+     */
     protected $literals = [1 => 'MON', 2 => 'TUE', 3 => 'WED', 4 => 'THU', 5 => 'FRI', 6 => 'SAT', 7 => 'SUN'];
 
     /**

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -28,12 +28,18 @@ class DayOfWeekField extends AbstractField
 
     protected $literals = [1 => 'MON', 2 => 'TUE', 3 => 'WED', 4 => 'THU', 5 => 'FRI', 6 => 'SAT', 7 => 'SUN'];
 
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->nthRange = range(1, 5);
         parent::__construct();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function isSatisfiedBy(DateTime $date, $value)
     {
         if ($value == '?') {
@@ -127,6 +133,9 @@ class DayOfWeekField extends AbstractField
         return $this->isSatisfied($fieldValue, $value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -3,6 +3,7 @@
 namespace Cron;
 
 use DateTime;
+use DateTimeInterface;
 use InvalidArgumentException;
 
 /**
@@ -51,8 +52,10 @@ class DayOfWeekField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable $date
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
         if ($value == '?') {
             return true;
@@ -71,7 +74,7 @@ class DayOfWeekField extends AbstractField
             $weekday = str_replace('7', '0', $weekday);
 
             $tdate = clone $date;
-            $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
+            $tdate = $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
             while ($tdate->format('w') != $weekday) {
                 $tdateClone = new DateTime();
                 $tdate = $tdateClone
@@ -114,7 +117,7 @@ class DayOfWeekField extends AbstractField
             }
 
             $tdate = clone $date;
-            $tdate->setDate($currentYear, $currentMonth, 1);
+            $tdate = $tdate->setDate($currentYear, $currentMonth, 1);
             $dayCount = 0;
             $currentDay = 1;
             while ($currentDay < $lastDayOfMonth + 1) {
@@ -123,7 +126,7 @@ class DayOfWeekField extends AbstractField
                         break;
                     }
                 }
-                $tdate->setDate($currentYear, $currentMonth, ++$currentDay);
+                $tdate = $tdate->setDate($currentYear, $currentMonth, ++$currentDay);
             }
 
             return $date->format('j') == $currentDay;
@@ -149,15 +152,15 @@ class DayOfWeekField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable &$date
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTimeInterface &$date, $invert = false)
     {
         if ($invert) {
-            $date->modify('-1 day');
-            $date->setTime(23, 59, 0);
+            $date = $date->modify('-1 day')->setTime(23, 59, 0);
         } else {
-            $date->modify('+1 day');
-            $date->setTime(0, 0, 0);
+            $date = $date->modify('+1 day')->setTime(0, 0, 0);
         }
 
         return $this;

--- a/src/Cron/DayOfWeekField.php
+++ b/src/Cron/DayOfWeekField.php
@@ -49,7 +49,9 @@ class DayOfWeekField extends AbstractField
 
         // Find out if this is the last specific weekday of the month
         if (strpos($value, 'L')) {
-            $weekday = str_replace('7', '0', substr($value, 0, strpos($value, 'L')));
+            $weekday = $this->convertLiterals(substr($value, 0, strpos($value, 'L')));
+            $weekday = str_replace('7', '0', $weekday);
+
             $tdate = clone $date;
             $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
             while ($tdate->format('w') != $weekday) {

--- a/src/Cron/FieldFactory.php
+++ b/src/Cron/FieldFactory.php
@@ -30,7 +30,7 @@ class FieldFactory implements FieldFactoryInterface
         return $this->fields[$position] ?? $this->fields[$position] = $this->instantiateField($position);
     }
 
-    private function instantiateField($position): FieldInterface
+    private function instantiateField(int $position): FieldInterface
     {
         switch ($position) {
             case CronExpression::MINUTE:

--- a/src/Cron/FieldFactory.php
+++ b/src/Cron/FieldFactory.php
@@ -44,7 +44,7 @@ class FieldFactory
                     break;
                 default:
                     throw new InvalidArgumentException(
-                        $position . ' is not a valid position'
+                        ($position + 1) . ' is not a valid position'
                     );
             }
         }

--- a/src/Cron/FieldFactory.php
+++ b/src/Cron/FieldFactory.php
@@ -25,30 +25,26 @@ class FieldFactory
      */
     public function getField($position)
     {
-        if (!isset($this->fields[$position])) {
-            switch ($position) {
-                case 0:
-                    $this->fields[$position] = new MinutesField();
-                    break;
-                case 1:
-                    $this->fields[$position] = new HoursField();
-                    break;
-                case 2:
-                    $this->fields[$position] = new DayOfMonthField();
-                    break;
-                case 3:
-                    $this->fields[$position] = new MonthField();
-                    break;
-                case 4:
-                    $this->fields[$position] = new DayOfWeekField();
-                    break;
-                default:
-                    throw new InvalidArgumentException(
-                        ($position + 1) . ' is not a valid position'
-                    );
-            }
+        return $this->fields[$position] ?? $this->fields[$position] = $this->instantiateField($position);
+    }
+
+    private function instantiateField($position): FieldInterface
+    {
+        switch ($position) {
+            case CronExpression::MINUTE:
+                return new MinutesField();
+            case CronExpression::HOUR:
+                return new HoursField();
+            case CronExpression::DAY:
+                return new DayOfMonthField();
+            case CronExpression::MONTH:
+                return new MonthField();
+            case CronExpression::WEEKDAY:
+                return new DayOfWeekField();
         }
 
-        return $this->fields[$position];
+        throw new InvalidArgumentException(
+            ($position + 1) . ' is not a valid position'
+        );
     }
 }

--- a/src/Cron/FieldFactory.php
+++ b/src/Cron/FieldFactory.php
@@ -1,46 +1,55 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use InvalidArgumentException;
 
 /**
- * CRON field factory implementing a flyweight factory
- * @link http://en.wikipedia.org/wiki/Cron
+ * CRON field factory implementing a flyweight factory.
+ *
+ * @see http://en.wikipedia.org/wiki/Cron
  */
 class FieldFactory
 {
     /**
      * @var array Cache of instantiated fields
      */
-    private $fields = array();
+    private $fields = [];
 
     /**
-     * Get an instance of a field object for a cron expression position
+     * Get an instance of a field object for a cron expression position.
      *
      * @param int $position CRON expression position value to retrieve
      *
-     * @return FieldInterface
      * @throws InvalidArgumentException if a position is not valid
+     *
+     * @return FieldInterface
      */
-    public function getField($position)
+    public function getField(int $position): FieldInterface
     {
         if (!isset($this->fields[$position])) {
             switch ($position) {
                 case 0:
                     $this->fields[$position] = new MinutesField();
+
                     break;
                 case 1:
                     $this->fields[$position] = new HoursField();
+
                     break;
                 case 2:
                     $this->fields[$position] = new DayOfMonthField();
+
                     break;
                 case 3:
                     $this->fields[$position] = new MonthField();
+
                     break;
                 case 4:
                     $this->fields[$position] = new DayOfWeekField();
+
                     break;
                 default:
                     throw new InvalidArgumentException(

--- a/src/Cron/FieldFactory.php
+++ b/src/Cron/FieldFactory.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
  * CRON field factory implementing a flyweight factory
  * @link http://en.wikipedia.org/wiki/Cron
  */
-class FieldFactory
+class FieldFactory implements FieldFactoryInterface
 {
     /**
      * @var array Cache of instantiated fields

--- a/src/Cron/FieldFactoryInterface.php
+++ b/src/Cron/FieldFactoryInterface.php
@@ -4,5 +4,5 @@ namespace Cron;
 
 interface FieldFactoryInterface
 {
-    public function getField(int $position);
+    public function getField(int $position): FieldInterface;
 }

--- a/src/Cron/FieldFactoryInterface.php
+++ b/src/Cron/FieldFactoryInterface.php
@@ -2,10 +2,7 @@
 
 namespace Cron;
 
-
 interface FieldFactoryInterface
 {
-
     public function getField($position);
-
 }

--- a/src/Cron/FieldFactoryInterface.php
+++ b/src/Cron/FieldFactoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Cron;
+
+
+interface FieldFactoryInterface
+{
+
+    public function getField($position);
+
+}

--- a/src/Cron/FieldFactoryInterface.php
+++ b/src/Cron/FieldFactoryInterface.php
@@ -4,5 +4,5 @@ namespace Cron;
 
 interface FieldFactoryInterface
 {
-    public function getField($position);
+    public function getField(int $position);
 }

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -25,12 +25,13 @@ interface FieldInterface
      * When a CRON expression is not satisfied, this method is used to increment
      * or decrement a DateTime object by the unit of the cron field.
      *
-     * @param DateTimeInterface &$date  DateTime object to change
-     * @param bool              $invert (optional) Set to TRUE to decrement
+     * @param DateTimeInterface $date DateTime object to change
+     * @param bool $invert (optional) Set to TRUE to decrement
+     * @param string|null $parts (optional) Set parts to use
      *
      * @return FieldInterface
      */
-    public function increment(DateTimeInterface &$date, $invert = false): FieldInterface;
+    public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface;
 
     /**
      * Validates a CRON expression for a given field.

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -14,6 +14,7 @@ interface FieldInterface
     /**
      * Check if the respective value of a DateTime field satisfies a CRON exp.
      *
+     * @internal
      * @param DateTimeInterface $date  DateTime object to check
      * @param string            $value CRON expression to test against
      *
@@ -25,6 +26,7 @@ interface FieldInterface
      * When a CRON expression is not satisfied, this method is used to increment
      * or decrement a DateTime object by the unit of the cron field.
      *
+     * @internal
      * @param DateTimeInterface $date DateTime object to change
      * @param bool $invert (optional) Set to TRUE to decrement
      * @param string|null $parts (optional) Set parts to use

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -19,7 +19,7 @@ interface FieldInterface
      *
      * @return bool Returns TRUE if satisfied, FALSE otherwise
      */
-    public function isSatisfiedBy(DateTimeInterface $date, $value): bool;
+    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert): bool;
 
     /**
      * When a CRON expression is not satisfied, this method is used to increment

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Cron;
+
 use DateTime;
 
 /**

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -1,41 +1,44 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use DateTime;
 
 /**
- * CRON field interface
+ * CRON field interface.
  */
 interface FieldInterface
 {
     /**
-     * Check if the respective value of a DateTime field satisfies a CRON exp
+     * Check if the respective value of a DateTime field satisfies a CRON exp.
      *
-     * @param DateTime $date  DateTime object to check
-     * @param string   $value CRON expression to test against
+     * @param DateTime $date DateTime object to check
+     * @param string $value CRON expression to test against
      *
      * @return bool Returns TRUE if satisfied, FALSE otherwise
      */
-    public function isSatisfiedBy(DateTime $date, $value);
+    public function isSatisfiedBy(DateTime $date, string $value): bool;
 
     /**
      * When a CRON expression is not satisfied, this method is used to increment
-     * or decrement a DateTime object by the unit of the cron field
+     * or decrement a DateTime object by the unit of the cron field.
      *
-     * @param DateTime $date   DateTime object to change
-     * @param bool     $invert (optional) Set to TRUE to decrement
+     * @param DateTime $date DateTime object to change
+     * @param bool $invert (optional) Set to TRUE to decrement
+     * @param null|string $parts
      *
      * @return FieldInterface
      */
-    public function increment(DateTime $date, $invert = false);
+    public function increment(DateTime $date, bool $invert = false, ?string $parts = null): FieldInterface;
 
     /**
-     * Validates a CRON expression for a given field
+     * Validates a CRON expression for a given field.
      *
      * @param string $value CRON expression value to validate
      *
      * @return bool Returns TRUE if valid, FALSE otherwise
      */
-    public function validate($value);
+    public function validate(string $value): bool;
 }

--- a/src/Cron/FieldInterface.php
+++ b/src/Cron/FieldInterface.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * CRON field interface
@@ -12,23 +12,23 @@ interface FieldInterface
     /**
      * Check if the respective value of a DateTime field satisfies a CRON exp
      *
-     * @param DateTime $date  DateTime object to check
-     * @param string   $value CRON expression to test against
+     * @param DateTimeInterface $date  DateTime object to check
+     * @param string            $value CRON expression to test against
      *
      * @return bool Returns TRUE if satisfied, FALSE otherwise
      */
-    public function isSatisfiedBy(DateTime $date, $value);
+    public function isSatisfiedBy(DateTimeInterface $date, $value);
 
     /**
      * When a CRON expression is not satisfied, this method is used to increment
      * or decrement a DateTime object by the unit of the cron field
      *
-     * @param DateTime $date   DateTime object to change
-     * @param bool     $invert (optional) Set to TRUE to decrement
+     * @param DateTimeInterface &$date  DateTime object to change
+     * @param bool              $invert (optional) Set to TRUE to decrement
      *
      * @return FieldInterface
      */
-    public function increment(DateTime $date, $invert = false);
+    public function increment(DateTimeInterface &$date, $invert = false);
 
     /**
      * Validates a CRON expression for a given field

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -25,7 +25,7 @@ class HoursField extends AbstractField
     /**
      * @var array|null Transitions returned by DateTimeZone::getTransitions()
      */
-    protected $transitions = null;
+    protected $transitions = [];
 
     /**
      * @var int|null Timestamp of the start of the transitions range
@@ -92,7 +92,7 @@ class HoursField extends AbstractField
                 $dtLimitStart->getTimestamp(),
                 $dtLimitEnd->getTimestamp()
             );
-            if ($this->transitions === false) {
+            if (empty($this->transitions)) {
                 return null;
             }
             $this->transitionsStart = $dtLimitStart->getTimestamp();

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -33,7 +33,7 @@ class HoursField extends AbstractField
     /**
      * {@inheritdoc}
      *
-     * @param \DateTime|\DateTimeImmutable &$date
+     * @param \DateTime|\DateTimeImmutable $date
      * @param string|null                  $parts
      */
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -50,7 +50,7 @@ class HoursField extends AbstractField
 
         // Are we on the edge of a transition
         $lastTransition = $this->getPastTransition($date);
-        if (($lastTransition !== null) && ($lastTransition["ts"] > ($date->format('U') - 3600))) {
+        if (($lastTransition !== null) && ($lastTransition["ts"] > ((int) $date->format('U') - 3600))) {
             $dtLastOffset = clone $date;
             $this->timezoneSafeModify($dtLastOffset, "-1 hour");
             $lastOffset = $dtLastOffset->getOffset();

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -92,6 +92,9 @@ class HoursField extends AbstractField
                 $dtLimitStart->getTimestamp(),
                 $dtLimitEnd->getTimestamp()
             );
+            if ($this->transitions === false) {
+                return null;
+            }
             $this->transitionsStart = $dtLimitStart->getTimestamp();
             $this->transitionsEnd = $dtLimitEnd->getTimestamp();
         }

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -23,31 +23,110 @@ class HoursField extends AbstractField
     protected $rangeEnd = 23;
 
     /**
+     * @var array|null Transitions returned by DateTimeZone::getTransitions()
+     */
+    protected $transitions = null;
+
+    /**
+     * @var int|null Timestamp of the start of the transitions range
+     */
+    protected $transitionsStart = null;
+
+    /**
+     * @var int|null Timestamp of the end of the transitions range
+     */
+    protected $transitionsEnd = null;
+
+    /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTimeInterface $date, $value): bool
+    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert): bool
     {
-        return $this->isSatisfied((int) $date->format('H'), $value);
+        $checkValue = (int) $date->format('H');
+        $retval = $this->isSatisfied($checkValue, $value);
+        if ($retval) {
+            return $retval;
+        }
+
+        // Are we on the edge of a transition
+        $lastTransition = $this->getPastTransition($date);
+        if (($lastTransition !== null) && ($lastTransition["ts"] > ($date->format('U') - 3600))) {
+            $dtLastOffset = clone $date;
+            $this->timezoneSafeModify($dtLastOffset, "-1 hour");
+            $lastOffset = $dtLastOffset->getOffset();
+
+            $dtNextOffset = clone $date;
+            $this->timezoneSafeModify($dtNextOffset, "+1 hour");
+            $nextOffset = $dtNextOffset->getOffset();
+
+            $offsetChange = $nextOffset - $lastOffset;
+            if ($offsetChange >= 3600) {
+                $checkValue -= 1;
+                return $this->isSatisfied($checkValue, $value);
+            }
+            if ((! $invert) && ($offsetChange <= -3600)) {
+                $checkValue += 1;
+                return $this->isSatisfied($checkValue, $value);
+            }
+        }
+
+        return $retval;
+    }
+
+    public function getPastTransition(DateTimeInterface $date): ?array
+    {
+        $currentTimestamp = (int) $date->format('U');
+        if (
+            ($this->transitions === null)
+            || ($this->transitionsStart < ($currentTimestamp + 86400))
+            || ($this->transitionsEnd > ($currentTimestamp - 86400))
+        ) {
+            // We start a day before current time so we can differentiate between the first transition entry
+            // and a change that happens now
+            $dtLimitStart = clone $date;
+            $dtLimitStart = $dtLimitStart->modify("-12 months");
+            $dtLimitEnd = clone $date;
+            $dtLimitEnd = $dtLimitEnd->modify('+12 months');
+
+            $this->transitions = $date->getTimezone()->getTransitions(
+                $dtLimitStart->getTimestamp(),
+                $dtLimitEnd->getTimestamp()
+            );
+            $this->transitionsStart = $dtLimitStart->getTimestamp();
+            $this->transitionsEnd = $dtLimitEnd->getTimestamp();
+        }
+
+        $nextTransition = null;
+        foreach ($this->transitions as $transition) {
+            if ($transition["ts"] > $currentTimestamp) {
+                continue;
+            }
+
+            if (($nextTransition !== null) && ($transition["ts"] < $nextTransition["ts"])) {
+                continue;
+            }
+
+            $nextTransition = $transition;
+        }
+
+        return ($nextTransition ?? null);
     }
 
     /**
      * {@inheritdoc}
      *
-     * @param \DateTime|\DateTimeImmutable $date
      * @param string|null                  $parts
      */
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
+        $originalTimestamp = (int) $date->format('U');
+
         // Change timezone to UTC temporarily. This will
         // allow us to go back or forwards and hour even
         // if DST will be changed between the hours.
         if (null === $parts || '*' === $parts) {
-            $timezone = $date->getTimezone();
-            $date = $date->setTimezone(new DateTimeZone('UTC'));
-            $date = $date->modify(($invert ? '-' : '+') . '1 hour');
-            $date = $date->setTimezone($timezone);
-
-            $date = $date->setTime((int)$date->format('H'), $invert ? 59 : 0);
+            $date = $this->timezoneSafeModify($date, ($invert ? "-" : "+") ."1 hour");
+            $date = $this->setTimeHour($date, $invert, $originalTimestamp);
             return $this;
         }
 
@@ -57,7 +136,7 @@ class HoursField extends AbstractField
             $hours = array_merge($hours, $this->getRangeForExpression($part, 23));
         }
 
-        $current_hour = $date->format('H');
+        $current_hour = (int) $date->format('H');
         $position = $invert ? \count($hours) - 1 : 0;
         $countHours = \count($hours);
         if ($countHours > 1) {
@@ -71,12 +150,53 @@ class HoursField extends AbstractField
             }
         }
 
-        $hour = (int) $hours[$position];
-        if ((!$invert && (int) $date->format('H') >= $hour) || ($invert && (int) $date->format('H') <= $hour)) {
-            $date = $date->modify(($invert ? '-' : '+') . '1 day');
-            $date = $date->setTime($invert ? 23 : 0, $invert ? 59 : 0);
+        $target = (int) $hours[$position];
+        $originalHour = (int)$date->format('H');
+
+        $originalDay = (int)$date->format('d');
+        $previousOffset = $date->getOffset();
+
+        if (! $invert) {
+            if ($originalHour >= $target) {
+                $distance = 24 - $originalHour;
+                $date = $this->timezoneSafeModify($date, "+{$distance} hours");
+
+                $actualDay = (int)$date->format('d');
+                $actualHour = (int)$date->format('H');
+                if (($actualDay !== ($originalDay + 1)) && ($actualHour !== 0)) {
+                    $offsetChange = ($previousOffset - $date->getOffset());
+                    $date = $this->timezoneSafeModify($date, "+{$offsetChange} seconds");
+                }
+
+                $originalHour = (int)$date->format('H');
+            }
+
+            $distance = $target - $originalHour;
+            $date = $this->timezoneSafeModify($date, "+{$distance} hours");
         } else {
-            $date = $date->setTime($hour, $invert ? 59 : 0);
+            if ($originalHour <= $target) {
+                $distance = ($originalHour + 1);
+                $date = $this->timezoneSafeModify($date, "-" . $distance . " hours");
+
+                $actualDay = (int)$date->format('d');
+                $actualHour = (int)$date->format('H');
+                if (($actualDay !== ($originalDay - 1)) && ($actualHour !== 23)) {
+                    $offsetChange = ($previousOffset - $date->getOffset());
+                    $date = $this->timezoneSafeModify($date, "+{$offsetChange} seconds");
+                }
+
+                $originalHour = (int)$date->format('H');
+            }
+
+            $distance = $originalHour - $target;
+            $date = $this->timezoneSafeModify($date, "-{$distance} hours");
+        }
+
+        $date = $this->setTimeHour($date, $invert, $originalTimestamp);
+
+        $actualHour = (int)$date->format('H');
+        if ($invert && ($actualHour === ($target - 1) || (($actualHour === 23) && ($target === 0)))) {
+            $date = $this->timezoneSafeModify($date, "+1 hour");
         }
 
         return $this;

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -47,7 +47,7 @@ class HoursField extends AbstractField
             $date = $date->modify(($invert ? '-' : '+') . '1 hour');
             $date = $date->setTimezone($timezone);
 
-            $date = $date->setTime($date->format('H'), $invert ? 59 : 0);
+            $date = $date->setTime((int)$date->format('H'), $invert ? 59 : 0);
             return $this;
         }
 

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -1,44 +1,46 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use DateTime;
 use DateTimeZone;
 
 /**
- * Hours field.  Allows: * , / -
+ * Hours field.  Allows: * , / -.
  */
 class HoursField extends AbstractField
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeStart = 0;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeEnd = 23;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, string $value): bool
     {
-        return $this->isSatisfied($date->format('H'), $value);
+        return $this->isSatisfied((int) $date->format('H'), $value);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
-     * @param string|null $parts
+     * @param null|string $parts
      */
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTime $date, bool $invert = false, ?string $parts = null): FieldInterface
     {
         // Change timezone to UTC temporarily. This will
         // allow us to go back or forwards and hour even
         // if DST will be changed between the hours.
-        if (is_null($parts) || $parts == '*') {
+        if (null === $parts || '*' === $parts) {
             $timezone = $date->getTimezone();
             $date->setTimezone(new DateTimeZone('UTC'));
             if ($invert) {
@@ -48,34 +50,36 @@ class HoursField extends AbstractField
             }
             $date->setTimezone($timezone);
 
-            $date->setTime($date->format('H'), $invert ? 59 : 0);
+            $date->setTime((int) $date->format('H'), $invert ? 59 : 0);
+
             return $this;
         }
 
-        $parts = strpos($parts, ',') !== false ? explode(',', $parts) : array($parts);
-        $hours = array();
+        $parts = false !== strpos($parts, ',') ? explode(',', $parts) : [$parts];
+        $hours = [];
         foreach ($parts as $part) {
             $hours = array_merge($hours, $this->getRangeForExpression($part, 23));
         }
 
         $current_hour = $date->format('H');
-        $position = $invert ? count($hours) - 1 : 0;
-        if (count($hours) > 1) {
-            for ($i = 0; $i < count($hours) - 1; $i++) {
+        $position = $invert ? \count($hours) - 1 : 0;
+        $countHours = \count($hours);
+        if ($countHours > 1) {
+            for ($i = 0; $i < $countHours - 1; ++$i) {
                 if ((!$invert && $current_hour >= $hours[$i] && $current_hour < $hours[$i + 1]) ||
                     ($invert && $current_hour > $hours[$i] && $current_hour <= $hours[$i + 1])) {
                     $position = $invert ? $i : $i + 1;
+
                     break;
                 }
             }
         }
 
-        $hour = $hours[$position];
-        if ((!$invert && $date->format('H') >= $hour) || ($invert && $date->format('H') <= $hour)) {
+        $hour = (int) $hours[$position];
+        if ((!$invert && (int) $date->format('H') >= $hour) || ($invert && (int) $date->format('H') <= $hour)) {
             $date->modify(($invert ? '-' : '+') . '1 day');
             $date->setTime($invert ? 23 : 0, $invert ? 59 : 0);
-        }
-        else {
+        } else {
             $date->setTime($hour, $invert ? 59 : 0);
         }
 

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -10,7 +10,14 @@ use DateTimeZone;
  */
 class HoursField extends AbstractField
 {
+    /**
+     * @inheritDoc
+     */
     protected $rangeStart = 0;
+
+    /**
+     * @inheritDoc
+     */
     protected $rangeEnd = 23;
 
     /**

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -1,9 +1,9 @@
 <?php
 
 namespace Cron;
+
 use DateTime;
 use DateTimeZone;
-
 
 /**
  * Hours field.  Allows: * , / -

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 
 /**
@@ -23,32 +23,33 @@ class HoursField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
+        if ($value == '?') {
+            return true;
+        }
+
         return $this->isSatisfied($date->format('H'), $value);
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param string|null $parts
+     * @param \DateTime|\DateTimeImmutable &$date
+     * @param string|null                  $parts
      */
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTimeInterface &$date, $invert = false, $parts = null)
     {
         // Change timezone to UTC temporarily. This will
         // allow us to go back or forwards and hour even
         // if DST will be changed between the hours.
         if (is_null($parts) || $parts == '*') {
             $timezone = $date->getTimezone();
-            $date->setTimezone(new DateTimeZone('UTC'));
-            if ($invert) {
-                $date->modify('-1 hour');
-            } else {
-                $date->modify('+1 hour');
-            }
-            $date->setTimezone($timezone);
+            $date = $date->setTimezone(new DateTimeZone('UTC'));
+            $date = $date->modify(($invert ? '-' : '+') . '1 hour');
+            $date = $date->setTimezone($timezone);
 
-            $date->setTime($date->format('H'), $invert ? 59 : 0);
+            $date = $date->setTime($date->format('H'), $invert ? 59 : 0);
             return $this;
         }
 
@@ -72,11 +73,11 @@ class HoursField extends AbstractField
 
         $hour = $hours[$position];
         if ((!$invert && $date->format('H') >= $hour) || ($invert && $date->format('H') <= $hour)) {
-            $date->modify(($invert ? '-' : '+') . '1 day');
-            $date->setTime($invert ? 23 : 0, $invert ? 59 : 0);
+            $date = $date->modify(($invert ? '-' : '+') . '1 day');
+            $date = $date->setTime($invert ? 23 : 0, $invert ? 59 : 0);
         }
         else {
-            $date->setTime($hour, $invert ? 59 : 0);
+            $date = $date->setTime($hour, $invert ? 59 : 0);
         }
 
         return $this;

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -125,7 +125,12 @@ class HoursField extends AbstractField
         // allow us to go back or forwards and hour even
         // if DST will be changed between the hours.
         if (null === $parts || '*' === $parts) {
-            $date = $this->timezoneSafeModify($date, ($invert ? "-" : "+") ."1 hour");
+            if ($invert) {
+                $date = $date->sub(new \DateInterval('PT1H'));
+            } else {
+                $date = $date->add(new \DateInterval('PT1H'));
+            }
+
             $date = $this->setTimeHour($date, $invert, $originalTimestamp);
             return $this;
         }

--- a/src/Cron/HoursField.php
+++ b/src/Cron/HoursField.php
@@ -13,11 +13,19 @@ class HoursField extends AbstractField
     protected $rangeStart = 0;
     protected $rangeEnd = 23;
 
+    /**
+     * @inheritDoc
+     */
     public function isSatisfiedBy(DateTime $date, $value)
     {
         return $this->isSatisfied($date->format('H'), $value);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param string|null $parts
+     */
     public function increment(DateTime $date, $invert = false, $parts = null)
     {
         // Change timezone to UTC temporarily. This will

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -37,7 +37,7 @@ class MinutesField extends AbstractField
      * {@inheritdoc}
      * {@inheritDoc}
      *
-     * @param \DateTime|\DateTimeImmutable &$date
+     * @param \DateTime|\DateTimeImmutable $date
      * @param string|null                  $parts
      */
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -42,7 +42,7 @@ class MinutesField extends AbstractField
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
         if (is_null($parts)) {
-            $date = $date->modify(($invert ? '-' : '+'). '1 minute');
+            $date = $this->timezoneSafeModify($date, ($invert ? "-" : "+") ."1 minute");
             return $this;
         }
 

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -14,7 +14,7 @@ class MinutesField extends AbstractField
     /**
      * {@inheritdoc}
      */
-    protected $rangeStart = 0;
+    protected $rangeStart = 0; 
 
     /**
      * {@inheritdoc}
@@ -24,7 +24,7 @@ class MinutesField extends AbstractField
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert):bool
+    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert):bool 
     {
         if ($value === '?') {
             return true;
@@ -43,15 +43,16 @@ class MinutesField extends AbstractField
     {
         if (is_null($parts)) {
             $date = $this->timezoneSafeModify($date, ($invert ? "-" : "+") ."1 minute");
-            return $this;
+            return $this; 
         }
 
-        $current_minute = (int) $date->format('i');
+        $current_minute = (int) $date->format('i'); 
 
-        $parts = false !== strpos($parts, ',') ? explode(',', $parts) : [$parts];
-        $minutes = [];
+        $parts = false !== strpos($parts, ',') ? explode(',', $parts) : [$parts]; 
+        sort($parts);
+        $minutes = []; 
         foreach ($parts as $part) {
-            $minutes = array_merge($minutes, $this->getRangeForExpression($part, 59));
+            $minutes = array_merge($minutes, $this->getRangeForExpression($part, 59)); 
         }
 
         $position = $invert ? \count($minutes) - 1 : 0;
@@ -67,7 +68,7 @@ class MinutesField extends AbstractField
         }
 
         $target = (int) $minutes[$position];
-        $originalMinute = (int) $date->format("i");
+        $originalMinute = (int) $date->format("i"); 
 
         if (! $invert) {
             if ($originalMinute >= $target) {
@@ -78,7 +79,7 @@ class MinutesField extends AbstractField
             }
 
             $distance = $target - $originalMinute;
-            $date = $this->timezoneSafeModify($date, "+{$distance} minutes");
+            $date = $this->timezoneSafeModify($date, "+{$distance} minutes"); 
         } else {
             if ($originalMinute <= $target) {
                 $distance = ($originalMinute + 1);

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -13,11 +13,19 @@ class MinutesField extends AbstractField
     protected $rangeStart = 0;
     protected $rangeEnd = 59;
 
+    /**
+     * @inheritDoc
+     */
     public function isSatisfiedBy(DateTime $date, $value)
     {
         return $this->isSatisfied($date->format('i'), $value);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param string|null $parts
+     */
     public function increment(DateTime $date, $invert = false, $parts = null)
     {
         if (is_null($parts)) {

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * Minutes field.  Allows: * , / -
@@ -22,24 +22,25 @@ class MinutesField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
+        if ($value == '?') {
+            return true;
+        }
+
         return $this->isSatisfied($date->format('i'), $value);
     }
 
     /**
      * {@inheritDoc}
      *
-     * @param string|null $parts
+     * @param \DateTime|\DateTimeImmutable &$date
+     * @param string|null                  $parts
      */
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTimeInterface &$date, $invert = false, $parts = null)
     {
         if (is_null($parts)) {
-            if ($invert) {
-                $date->modify('-1 minute');
-            } else {
-                $date->modify('+1 minute');
-            }
+            $date = $date->modify(($invert ? '-' : '+') . '1 minute');
             return $this;
         }
 
@@ -62,11 +63,11 @@ class MinutesField extends AbstractField
         }
 
         if ((!$invert && $current_minute >= $minutes[$position]) || ($invert && $current_minute <= $minutes[$position])) {
-            $date->modify(($invert ? '-' : '+') . '1 hour');
-            $date->setTime($date->format('H'), $invert ? 59 : 0);
+            $date = $date->modify(($invert ? '-' : '+') . '1 hour');
+            $date = $date->setTime($date->format('H'), $invert ? 59 : 0);
         }
         else {
-            $date->setTime($date->format('H'), $minutes[$position]);
+            $date = $date->setTime($date->format('H'), $minutes[$position]);
         }
 
         return $this;

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -30,7 +30,7 @@ class MinutesField extends AbstractField
             return true;
         }
 
-        return $this->isSatisfied($date->format('i'), $value);
+        return $this->isSatisfied((int)$date->format('i'), $value);
     }
 
     /**

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -14,7 +14,7 @@ class MinutesField extends AbstractField
     /**
      * {@inheritdoc}
      */
-    protected $rangeStart = 0; 
+    protected $rangeStart = 0;
 
     /**
      * {@inheritdoc}
@@ -24,7 +24,7 @@ class MinutesField extends AbstractField
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert):bool 
+    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert):bool
     {
         if ($value === '?') {
             return true;
@@ -43,16 +43,16 @@ class MinutesField extends AbstractField
     {
         if (is_null($parts)) {
             $date = $this->timezoneSafeModify($date, ($invert ? "-" : "+") ."1 minute");
-            return $this; 
+            return $this;
         }
 
-        $current_minute = (int) $date->format('i'); 
+        $current_minute = (int) $date->format('i');
 
-        $parts = false !== strpos($parts, ',') ? explode(',', $parts) : [$parts]; 
+        $parts = false !== strpos($parts, ',') ? explode(',', $parts) : [$parts];
         sort($parts);
-        $minutes = []; 
+        $minutes = [];
         foreach ($parts as $part) {
-            $minutes = array_merge($minutes, $this->getRangeForExpression($part, 59)); 
+            $minutes = array_merge($minutes, $this->getRangeForExpression($part, 59));
         }
 
         $position = $invert ? \count($minutes) - 1 : 0;
@@ -68,7 +68,7 @@ class MinutesField extends AbstractField
         }
 
         $target = (int) $minutes[$position];
-        $originalMinute = (int) $date->format("i"); 
+        $originalMinute = (int) $date->format("i");
 
         if (! $invert) {
             if ($originalMinute >= $target) {
@@ -79,7 +79,7 @@ class MinutesField extends AbstractField
             }
 
             $distance = $target - $originalMinute;
-            $date = $this->timezoneSafeModify($date, "+{$distance} minutes"); 
+            $date = $this->timezoneSafeModify($date, "+{$distance} minutes");
         } else {
             if ($originalMinute <= $target) {
                 $distance = ($originalMinute + 1);

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -4,7 +4,6 @@ namespace Cron;
 
 use DateTime;
 
-
 /**
  * Minutes field.  Allows: * , / -
  */

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -10,7 +10,14 @@ use DateTime;
  */
 class MinutesField extends AbstractField
 {
+    /**
+     * @inheritDoc
+     */
     protected $rangeStart = 0;
+
+    /**
+     * @inheritDoc
+     */
     protected $rangeEnd = 59;
 
     /**

--- a/src/Cron/MinutesField.php
+++ b/src/Cron/MinutesField.php
@@ -1,61 +1,65 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use DateTime;
 
 /**
- * Minutes field.  Allows: * , / -
+ * Minutes field.  Allows: * , / -.
  */
 class MinutesField extends AbstractField
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeStart = 0;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeEnd = 59;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, String $value): bool
     {
-        return $this->isSatisfied($date->format('i'), $value);
+        return $this->isSatisfied((int) $date->format('i'), $value);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
-     * @param string|null $parts
+     * @param null|string $parts
      */
-    public function increment(DateTime $date, $invert = false, $parts = null)
+    public function increment(DateTime $date, bool $invert = false, ?string $parts = null): FieldInterface
     {
-        if (is_null($parts)) {
+        if (null === $parts) {
             if ($invert) {
                 $date->modify('-1 minute');
             } else {
                 $date->modify('+1 minute');
             }
+
             return $this;
         }
 
-        $parts = strpos($parts, ',') !== false ? explode(',', $parts) : array($parts);
-        $minutes = array();
+        $parts = false !== strpos($parts, ',') ? explode(',', $parts) : [$parts];
+        $minutes = [];
         foreach ($parts as $part) {
             $minutes = array_merge($minutes, $this->getRangeForExpression($part, 59));
         }
 
         $current_minute = $date->format('i');
-        $position = $invert ? count($minutes) - 1 : 0;
-        if (count($minutes) > 1) {
-            for ($i = 0; $i < count($minutes) - 1; $i++) {
+        $position = $invert ? \count($minutes) - 1 : 0;
+        if (\count($minutes) > 1) {
+            for ($i = 0; $i < \count($minutes) - 1; ++$i) {
                 if ((!$invert && $current_minute >= $minutes[$i] && $current_minute < $minutes[$i + 1]) ||
                     ($invert && $current_minute > $minutes[$i] && $current_minute <= $minutes[$i + 1])) {
                     $position = $invert ? $i : $i + 1;
+
                     break;
                 }
             }
@@ -63,10 +67,9 @@ class MinutesField extends AbstractField
 
         if ((!$invert && $current_minute >= $minutes[$position]) || ($invert && $current_minute <= $minutes[$position])) {
             $date->modify(($invert ? '-' : '+') . '1 hour');
-            $date->setTime($date->format('H'), $invert ? 59 : 0);
-        }
-        else {
-            $date->setTime($date->format('H'), $minutes[$position]);
+            $date->setTime((int) $date->format('H'), $invert ? 59 : 0);
+        } else {
+            $date->setTime((int) $date->format('H'), (int) $minutes[$position]);
         }
 
         return $this;

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -44,9 +44,9 @@ class MonthField extends AbstractField
     /**
      * @inheritDoc
      *
-     * @param \DateTime|\DateTimeImmutable &$date
+     * @param \DateTime|\DateTimeImmutable $date
      */
-    public function increment(DateTimeInterface &$date, $invert = false): FieldInterface
+    public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
         if ($invert) {
             $date = $date->modify('last day of previous month')->setTime(23, 59);

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -30,9 +30,9 @@ class MonthField extends AbstractField
     /**
      * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTimeInterface $date, $value): bool
+    public function isSatisfiedBy(DateTimeInterface $date, $value, bool $invert): bool
     {
-        if ($value == '?') {
+        if ($value === '?') {
             return true;
         }
 
@@ -48,10 +48,12 @@ class MonthField extends AbstractField
      */
     public function increment(DateTimeInterface &$date, $invert = false, $parts = null): FieldInterface
     {
-        if ($invert) {
-            $date = $date->modify('last day of previous month')->setTime(23, 59);
+        if (! $invert) {
+            $date = $date->modify('first day of next month');
+            $date = $date->setTime(0, 0);
         } else {
-            $date = $date->modify('first day of next month')->setTime(0, 0);
+            $date = $date->modify('last day of previous month');
+            $date = $date->setTime(23, 59);
         }
 
         return $this;

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -14,6 +14,9 @@ class MonthField extends AbstractField
     protected $literals = [1 => 'JAN', 2 => 'FEB', 3 => 'MAR', 4 => 'APR', 5 => 'MAY', 6 => 'JUN', 7 => 'JUL',
         8 => 'AUG', 9 => 'SEP', 10 => 'OCT', 11 => 'NOV', 12 => 'DEC'];
 
+    /**
+     * @inheritDoc
+     */
     public function isSatisfiedBy(DateTime $date, $value)
     {
         $value = $this->convertLiterals($value);
@@ -21,6 +24,9 @@ class MonthField extends AbstractField
         return $this->isSatisfied($date->format('m'), $value);
     }
 
+    /**
+     * @inheritDoc
+     */
     public function increment(DateTime $date, $invert = false)
     {
         if ($invert) {

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -9,8 +9,19 @@ use DateTime;
  */
 class MonthField extends AbstractField
 {
+    /**
+     * @inheritDoc
+     */
     protected $rangeStart = 1;
+
+    /**
+     * @inheritDoc
+     */
     protected $rangeEnd = 12;
+
+    /**
+     * @inheritDoc
+     */
     protected $literals = [1 => 'JAN', 2 => 'FEB', 3 => 'MAR', 4 => 'APR', 5 => 'MAY', 6 => 'JUN', 7 => 'JUL',
         8 => 'AUG', 9 => 'SEP', 10 => 'OCT', 11 => 'NOV', 12 => 'DEC'];
 

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -2,7 +2,7 @@
 
 namespace Cron;
 
-use DateTime;
+use DateTimeInterface;
 
 /**
  * Month field.  Allows: * , / -
@@ -28,8 +28,12 @@ class MonthField extends AbstractField
     /**
      * @inheritDoc
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTimeInterface $date, $value)
     {
+        if ($value == '?') {
+            return true;
+        }
+
         $value = $this->convertLiterals($value);
 
         return $this->isSatisfied($date->format('m'), $value);
@@ -37,15 +41,15 @@ class MonthField extends AbstractField
 
     /**
      * @inheritDoc
+     *
+     * @param \DateTime|\DateTimeImmutable &$date
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTimeInterface &$date, $invert = false)
     {
         if ($invert) {
-            $date->modify('last day of previous month');
-            $date->setTime(23, 59);
+            $date = $date->modify('last day of previous month')->setTime(23, 59);
         } else {
-            $date->modify('first day of next month');
-            $date->setTime(0, 0);
+            $date = $date->modify('first day of next month')->setTime(0, 0);
         }
 
         return $this;

--- a/src/Cron/MonthField.php
+++ b/src/Cron/MonthField.php
@@ -1,44 +1,46 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron;
 
 use DateTime;
 
 /**
- * Month field.  Allows: * , / -
+ * Month field.  Allows: * , / -.
  */
 class MonthField extends AbstractField
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeStart = 1;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $rangeEnd = 12;
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected $literals = [1 => 'JAN', 2 => 'FEB', 3 => 'MAR', 4 => 'APR', 5 => 'MAY', 6 => 'JUN', 7 => 'JUL',
-        8 => 'AUG', 9 => 'SEP', 10 => 'OCT', 11 => 'NOV', 12 => 'DEC'];
+        8 => 'AUG', 9 => 'SEP', 10 => 'OCT', 11 => 'NOV', 12 => 'DEC', ];
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function isSatisfiedBy(DateTime $date, $value)
+    public function isSatisfiedBy(DateTime $date, string $value): bool
     {
         $value = $this->convertLiterals($value);
 
-        return $this->isSatisfied($date->format('m'), $value);
+        return $this->isSatisfied((int) $date->format('m'), $value);
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function increment(DateTime $date, $invert = false)
+    public function increment(DateTime $date, bool $invert = false, ?string $parts = null): FieldInterface
     {
         if ($invert) {
             $date->modify('last day of previous month');
@@ -50,6 +52,4 @@ class MonthField extends AbstractField
 
         return $this;
     }
-
-
 }

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -3,6 +3,7 @@
 namespace Cron\Tests;
 
 use Cron\DayOfWeekField;
+use Cron\HoursField;
 use Cron\MinutesField;
 use Cron\MonthField;
 use PHPUnit\Framework\TestCase;
@@ -115,5 +116,31 @@ class AbstractFieldTest extends TestCase
         $this->assertFalse($f->isSatisfied('12', '3-11'));
         $this->assertFalse($f->isSatisfied('12', '3-7/2'));
         $this->assertFalse($f->isSatisfied('12', '11'));
+    }
+
+    /**
+     * Allows ranges and lists to coexist in the same expression
+     *
+     * @see https://github.com/dragonmantank/cron-expression/issues/5
+     */
+    public function testAllowRangesAndLists()
+    {
+        $expression = '5-7,11-13';
+        $f = new HoursField();
+        $this->assertTrue($f->validate($expression));
+    }
+
+    /**
+     * Makes sure that various types of ranges expand out properly
+     *
+     * @see https://github.com/dragonmantank/cron-expression/issues/5
+     */
+    public function testGetRangeForExpressionExpandsCorrectly()
+    {
+        $f = new HoursField();
+        $this->assertSame([5, 6, 7, 11, 12, 13], $f->getRangeForExpression('5-7,11-13', 23));
+        $this->assertSame(['5', '6', '7', '11', '12', '13'], $f->getRangeForExpression('5,6,7,11,12,13', 23));
+        $this->assertSame([0, 6, 12, 18], $f->getRangeForExpression('*/6', 23));
+        $this->assertSame([5, 11], $f->getRangeForExpression('5-13/6', 23));
     }
 }

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -96,13 +96,6 @@ class AbstractFieldTest extends TestCase
         $this->assertFalse($f->isInIncrementsOfRanges('34', '4/1'));
     }
 
-    public function testStepCannotBeLargerThanRange()
-    {
-        $this->expectException(\OutOfRangeException::class);
-        $f = new MonthField();
-        $f->isInIncrementsOfRanges('2', '3-12/13');
-    }
-
     /**
      * @covers \Cron\AbstractField::isSatisfied
      */

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\DayOfWeekField;
@@ -16,7 +18,7 @@ class AbstractFieldTest extends TestCase
     /**
      * @covers \Cron\AbstractField::isRange
      */
-    public function testTestsIfRange()
+    public function testTestsIfRange(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->isRange('1-2'));
@@ -26,7 +28,7 @@ class AbstractFieldTest extends TestCase
     /**
      * @covers \Cron\AbstractField::isIncrementsOfRanges
      */
-    public function testTestsIfIncrementsOfRanges()
+    public function testTestsIfIncrementsOfRanges(): void
     {
         $f = new DayOfWeekField();
         $this->assertFalse($f->isIncrementsOfRanges('1-2'));
@@ -38,85 +40,85 @@ class AbstractFieldTest extends TestCase
     /**
      * @covers \Cron\AbstractField::isInRange
      */
-    public function testTestsIfInRange()
+    public function testTestsIfInRange(): void
     {
         $f = new DayOfWeekField();
-        $this->assertTrue($f->isInRange('1', '1-2'));
-        $this->assertTrue($f->isInRange('2', '1-2'));
-        $this->assertTrue($f->isInRange('5', '4-12'));
-        $this->assertFalse($f->isInRange('3', '4-12'));
-        $this->assertFalse($f->isInRange('13', '4-12'));
+        $this->assertTrue($f->isInRange(1, '1-2'));
+        $this->assertTrue($f->isInRange(2, '1-2'));
+        $this->assertTrue($f->isInRange(5, '4-12'));
+        $this->assertFalse($f->isInRange(3, '4-12'));
+        $this->assertFalse($f->isInRange(13, '4-12'));
     }
 
     /**
      * @covers \Cron\AbstractField::isInIncrementsOfRanges
      */
-    public function testTestsIfInIncrementsOfRangesOnZeroStartRange()
+    public function testTestsIfInIncrementsOfRangesOnZeroStartRange(): void
     {
         $f = new MinutesField();
-        $this->assertTrue($f->isInIncrementsOfRanges('3', '3-59/2'));
-        $this->assertTrue($f->isInIncrementsOfRanges('13', '3-59/2'));
-        $this->assertTrue($f->isInIncrementsOfRanges('15', '3-59/2'));
-        $this->assertTrue($f->isInIncrementsOfRanges('14', '*/2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('2', '3-59/13'));
-        $this->assertFalse($f->isInIncrementsOfRanges('14', '*/13'));
-        $this->assertFalse($f->isInIncrementsOfRanges('14', '3-59/2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('3', '2-59'));
-        $this->assertFalse($f->isInIncrementsOfRanges('3', '2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('3', '*'));
-        $this->assertFalse($f->isInIncrementsOfRanges('0', '*/0'));
-        $this->assertFalse($f->isInIncrementsOfRanges('1', '*/0'));
+        $this->assertTrue($f->isInIncrementsOfRanges(3, '3-59/2'));
+        $this->assertTrue($f->isInIncrementsOfRanges(13, '3-59/2'));
+        $this->assertTrue($f->isInIncrementsOfRanges(15, '3-59/2'));
+        $this->assertTrue($f->isInIncrementsOfRanges(14, '*/2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(2, '3-59/13'));
+        $this->assertFalse($f->isInIncrementsOfRanges(14, '*/13'));
+        $this->assertFalse($f->isInIncrementsOfRanges(14, '3-59/2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '2-59'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '*'));
+        $this->assertFalse($f->isInIncrementsOfRanges(0, '*/0'));
+        $this->assertFalse($f->isInIncrementsOfRanges(1, '*/0'));
 
-        $this->assertTrue($f->isInIncrementsOfRanges('4', '4/1'));
-        $this->assertFalse($f->isInIncrementsOfRanges('14', '4/1'));
-        $this->assertFalse($f->isInIncrementsOfRanges('34', '4/1'));
+        $this->assertTrue($f->isInIncrementsOfRanges(4, '4/1'));
+        $this->assertFalse($f->isInIncrementsOfRanges(14, '4/1'));
+        $this->assertFalse($f->isInIncrementsOfRanges(34, '4/1'));
     }
 
     /**
      * @covers \Cron\AbstractField::isInIncrementsOfRanges
      */
-    public function testTestsIfInIncrementsOfRangesOnOneStartRange()
+    public function testTestsIfInIncrementsOfRangesOnOneStartRange(): void
     {
         $f = new MonthField();
-        $this->assertTrue($f->isInIncrementsOfRanges('3', '3-12/2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('13', '3-12/2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('15', '3-12/2'));
-        $this->assertTrue($f->isInIncrementsOfRanges('3', '*/2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('3', '*/3'));
-        $this->assertTrue($f->isInIncrementsOfRanges('7', '*/3'));
-        $this->assertFalse($f->isInIncrementsOfRanges('14', '3-12/2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('3', '2-12'));
-        $this->assertFalse($f->isInIncrementsOfRanges('3', '2'));
-        $this->assertFalse($f->isInIncrementsOfRanges('3', '*'));
-        $this->assertFalse($f->isInIncrementsOfRanges('0', '*/0'));
-        $this->assertFalse($f->isInIncrementsOfRanges('1', '*/0'));
+        $this->assertTrue($f->isInIncrementsOfRanges(3, '3-12/2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(13, '3-12/2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(15, '3-12/2'));
+        $this->assertTrue($f->isInIncrementsOfRanges(3, '*/2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '*/3'));
+        $this->assertTrue($f->isInIncrementsOfRanges(7, '*/3'));
+        $this->assertFalse($f->isInIncrementsOfRanges(14, '3-12/2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '2-12'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '2'));
+        $this->assertFalse($f->isInIncrementsOfRanges(3, '*'));
+        $this->assertFalse($f->isInIncrementsOfRanges(0, '*/0'));
+        $this->assertFalse($f->isInIncrementsOfRanges(1, '*/0'));
 
-        $this->assertTrue($f->isInIncrementsOfRanges('4', '4/1'));
-        $this->assertFalse($f->isInIncrementsOfRanges('14', '4/1'));
-        $this->assertFalse($f->isInIncrementsOfRanges('34', '4/1'));
+        $this->assertTrue($f->isInIncrementsOfRanges(4, '4/1'));
+        $this->assertFalse($f->isInIncrementsOfRanges(14, '4/1'));
+        $this->assertFalse($f->isInIncrementsOfRanges(34, '4/1'));
     }
 
     /**
      * @covers \Cron\AbstractField::isSatisfied
      */
-    public function testTestsIfSatisfied()
+    public function testTestsIfSatisfied(): void
     {
         $f = new DayOfWeekField();
-        $this->assertTrue($f->isSatisfied('12', '3-13'));
-        $this->assertFalse($f->isSatisfied('15', '3-7/2'));
-        $this->assertTrue($f->isSatisfied('12', '*'));
-        $this->assertTrue($f->isSatisfied('12', '12'));
-        $this->assertFalse($f->isSatisfied('12', '3-11'));
-        $this->assertFalse($f->isSatisfied('12', '3-7/2'));
-        $this->assertFalse($f->isSatisfied('12', '11'));
+        $this->assertTrue($f->isSatisfied(12, '3-13'));
+        $this->assertFalse($f->isSatisfied(15, '3-7/2'));
+        $this->assertTrue($f->isSatisfied(12, '*'));
+        $this->assertTrue($f->isSatisfied(12, '12'));
+        $this->assertFalse($f->isSatisfied(12, '3-11'));
+        $this->assertFalse($f->isSatisfied(12, '3-7/2'));
+        $this->assertFalse($f->isSatisfied(12, '11'));
     }
 
     /**
-     * Allows ranges and lists to coexist in the same expression
+     * Allows ranges and lists to coexist in the same expression.
      *
      * @see https://github.com/dragonmantank/cron-expression/issues/5
      */
-    public function testAllowRangesAndLists()
+    public function testAllowRangesAndLists(): void
     {
         $expression = '5-7,11-13';
         $f = new HoursField();
@@ -124,11 +126,11 @@ class AbstractFieldTest extends TestCase
     }
 
     /**
-     * Makes sure that various types of ranges expand out properly
+     * Makes sure that various types of ranges expand out properly.
      *
      * @see https://github.com/dragonmantank/cron-expression/issues/5
      */
-    public function testGetRangeForExpressionExpandsCorrectly()
+    public function testGetRangeForExpressionExpandsCorrectly(): void
     {
         $f = new HoursField();
         $this->assertSame([5, 6, 7, 11, 12, 13], $f->getRangeForExpression('5-7,11-13', 23));

--- a/tests/Cron/AbstractFieldTest.php
+++ b/tests/Cron/AbstractFieldTest.php
@@ -137,5 +137,7 @@ class AbstractFieldTest extends TestCase
         $this->assertSame(['5', '6', '7', '11', '12', '13'], $f->getRangeForExpression('5,6,7,11,12,13', 23));
         $this->assertSame([0, 6, 12, 18], $f->getRangeForExpression('*/6', 23));
         $this->assertSame([5, 11], $f->getRangeForExpression('5-13/6', 23));
+        $this->assertSame([1, 2, 3, 4, 11, 13, 21, 24, 27, 40, 50], $f->getRangeForExpression('1-4,11-14/2,21-27/3,40-59/10', 59));
+        $this->assertSame(['1', '3', 5, 6, 7, 11, 12, 13, 14, 15, 17, 19, 21, '23'], $f->getRangeForExpression('1,3,5-7,11-15/1,17-22/2,23', 23));
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -652,7 +652,7 @@ class CronExpressionTest extends TestCase
     /**
      * Tests the getParts function.
      */
-    public function testGetParts()
+    public function testGetParts(): void
     {
         $e = CronExpression::factory('0 22 * * 1-5');
         $parts = $e->getParts();

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -26,6 +26,8 @@ class CronExpressionTest extends TestCase
         $this->assertSame('0 0 1 1 *', (new CronExpression('@annually'))->getExpression());
         $this->assertSame('0 0 1 1 *', (new CronExpression('@yearly'))->getExpression());
         $this->assertSame('0 0 * * 0', (new CronExpression('@weekly'))->getExpression());
+        $this->assertSame('0 0 * * *', (new CronExpression('@daily'))->getExpression());
+        $this->assertSame('0 0 * * *', (new CronExpression('@midnight'))->getExpression());
     }
 
     /**

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -443,6 +443,22 @@ class CronExpressionTest extends TestCase
     }
 
     /**
+     * If both day of month and day of week are set in an expression,
+     * we have to return a date which among dates matching either of two criteria is closest to the current date.
+     *
+     * Previously the earliest of dates was always returned, which was incorrect for previous run date.
+     *
+     * @covers \Cron\CronExpression::getRunDate
+     */
+    public function testGetRunDateHandlesSimultaneousDayOfMonthAndDayOfWeek(): void
+    {
+        $cron = new CronExpression('0 0 13 * 3');
+        $date = new DateTime("2021-07-15 00:00:00");
+        $this->assertEquals(new DateTime("2021-07-21 00:00:00"), $cron->getNextRunDate($date));
+        $this->assertEquals(new DateTime("2021-07-14 00:00:00"), $cron->getPreviousRunDate($date));
+    }
+
+    /**
      * @covers \Cron\CronExpression::getRunDate
      */
     public function testSkipsCurrentDateByDefault(): void

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -704,4 +704,24 @@ class CronExpressionTest extends TestCase
         $prev = $e->getPreviousRunDate(new \DateTime('2022-08-20 03:44:02'));
         $this->assertEquals($expected, $prev);
     }
+
+    public function testIssue128()
+    {
+        $e = new CronExpression('0 20 L 6,12 ?');
+        $expected = new \DateTime('2022-12-31 20:00:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'));
+        $this->assertEquals($expected, $next);
+
+        $expected = new \DateTime('2023-12-31 20:00:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'), 2);
+        $this->assertEquals($expected, $next);
+
+        $expected = new \DateTime('2022-06-30 20:00:00');
+        $prev = $e->getPreviousRunDate(new \DateTime('2022-08-20 03:44:02'));
+        $this->assertEquals($expected, $prev);
+
+        $expected = new \DateTime('2021-12-31 20:00:00');
+        $prev = $e->getPreviousRunDate(new \DateTime('2022-08-20 03:44:02'), 1);
+        $this->assertEquals($expected, $prev);
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -606,4 +606,17 @@ class CronExpressionTest extends TestCase
         $this->assertSame("2019-11-01 00:30:00", $runs[3]->format('Y-m-d H:i:s'));
         $this->assertSame("2019-11-04 00:30:00", $runs[4]->format('Y-m-d H:i:s'));
     }
+
+    /**
+     * Make sure that getNextRunDate() does not add arbitrary minutes
+     * 
+     * @see https://github.com/mtdowling/cron-expression/issues/152
+     */
+    public function testNextRunDateShouldNotAddMinutes()
+    {
+        $e = CronExpression::factory('* 19 * * *');
+        $nextRunDate = $e->getNextRunDate();
+
+        $this->assertSame("00", $nextRunDate->format("i"));
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -203,6 +203,7 @@ class CronExpressionTest extends TestCase
             ['0-59/59 10 * * *', strtotime('2021-08-25 09:00:00'), strtotime('2021-08-25 10:00:00'), false],
             ['0-59/59 10 * * *', strtotime('2021-08-25 10:01:00'), strtotime('2021-08-25 10:59:00'), false],
             ['0-59/65 10 * * *', strtotime('2021-08-25 10:01:00'), strtotime('2021-08-25 10:05:00'), false],
+            ['41-59/24 5 * * *', strtotime('2021-08-25 10:00:00'), strtotime('2021-08-26 05:41:00'), false],
         ];
     }
 

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -508,4 +508,28 @@ class CronExpressionTest extends TestCase
         // see https://github.com/dragonmantank/cron-expression/issues/5
         $this->assertTrue(CronExpression::isValidExpression('2,17,35,47 5-7,11-13 * * *'));
     }
+
+    /**
+     * Makes sure that 00 is considered a valid value for 0-based fields
+     * cronie allows numbers with a leading 0, so adding support for this as well
+     *
+     * @see https://github.com/dragonmantank/cron-expression/issues/12
+     */
+    public function testDoubleZeroIsValid()
+    {
+        $this->assertTrue(CronExpression::isValidExpression('00 * * * *'));
+        $this->assertTrue(CronExpression::isValidExpression('01 * * * *'));
+        $this->assertTrue(CronExpression::isValidExpression('* 00 * * *'));
+        $this->assertTrue(CronExpression::isValidExpression('* 01 * * *'));
+
+        $e = CronExpression::factory('00 * * * *');
+        $this->assertTrue($e->isDue(new DateTime('2014-04-07 00:00:00')));
+        $e = CronExpression::factory('01 * * * *');
+        $this->assertTrue($e->isDue(new DateTime('2014-04-07 00:01:00')));
+
+        $e = CronExpression::factory('* 00 * * *');
+        $this->assertTrue($e->isDue(new DateTime('2014-04-07 00:00:00')));
+        $e = CronExpression::factory('* 01 * * *');
+        $this->assertTrue($e->isDue(new DateTime('2014-04-07 01:00:00')));
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -687,12 +687,12 @@ class CronExpressionTest extends TestCase
     public function testIssue131()
     {
         $e = new CronExpression('* * * * 2');
-        $expected = new \DateTime('2020-10-27 00:00:00');
-        $next = $e->getNextRunDate(new DateTime('2020-10-23 15:31:45'));
+        $expected = new \DateTime('2020-10-27 00:00:00', new \DateTimeZone('Europe/Berlin'));
+        $next = $e->getNextRunDate(new DateTime('2020-10-23 15:31:45', new \DateTimeZone('Europe/Berlin')));
         $this->assertEquals($expected, $next);
 
-        $expected = new \DateTime('2020-10-20 23:59:00');
-        $prev = $e->getPreviousRunDate(new DateTime('2020-10-23 15:31:45'));
+        $expected = new \DateTime('2020-10-20 23:59:00', new \DateTimeZone('Europe/Berlin'));
+        $prev = $e->getPreviousRunDate(new DateTime('2020-10-23 15:31:45', new \DateTimeZone('Europe/Berlin')));
         $this->assertEquals($expected, $prev);
 
         $e = new CronExpression('15 1 1 9,11 *');

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -557,4 +557,16 @@ class CronExpressionTest extends TestCase
         $nextRunDate = $e->getNextRunDate(new DateTime('2014-05-07 00:00:00'));
         $this->assertSame('2015-04-01 00:00:00', $nextRunDate->format('Y-m-d H:i:s'));
     }
+
+    /**
+     * When there is an issue with a field, we should report the human readable position
+     *
+     * @see https://github.com/dragonmantank/cron-expression/issues/29
+     */
+    public function testFieldPositionIsHumanAdjusted()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("6 is not a valid position");
+        $e = CronExpression::factory('0 * * * * ? *');
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -563,6 +563,13 @@ class CronExpressionTest extends TestCase
         // Issue #125, this is just all sorts of wrong
         $this->assertFalse(CronExpression::isValidExpression('990 14 * * mon-fri0345345'));
 
+        // Issue #137, multiple question marks are not allowed
+        $this->assertFalse(CronExpression::isValidExpression('0 8 ? * ?'));
+        // Question marks are only allowed in dom and dow part
+        $this->assertFalse(CronExpression::isValidExpression('? * * * *'));
+        $this->assertFalse(CronExpression::isValidExpression('* ? * * *'));
+        $this->assertFalse(CronExpression::isValidExpression('* * * ? *'));
+
         // see https://github.com/dragonmantank/cron-expression/issues/5
         $this->assertTrue(CronExpression::isValidExpression('2,17,35,47 5-7,11-13 * * *'));
     }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -158,7 +158,7 @@ class CronExpressionTest extends TestCase
             // Test Day of the Week and the Day of the Month (issue #1)
             ['0 0 1 1 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false],
             ['0 0 1 JAN 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false],
-            ['0 0 1 * 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false],
+            ['0 0 1 * 0', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false],
             // Test the W day of the week modifier for day of the month field
             ['0 0 2W * *', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true],
             ['0 0 1W * *', strtotime('2011-05-01 00:00:00'), '2011-05-02 00:00:00', false],
@@ -180,7 +180,7 @@ class CronExpressionTest extends TestCase
             ['* * * * 3#4', strtotime('2011-07-01 00:00:00'), '2011-07-27 00:00:00', false],
 
             // Issue #7, documented example failed
-            ['3-59/15 6-12 */15 1 2-5', strtotime('2017-01-08 00:00:00'), '2017-01-31 06:03:00', false],
+            ['3-59/15 6-12 */15 1 2-5', strtotime('2017-01-08 00:00:00'), '2017-01-10 06:03:00', false],
 
             // https://github.com/laravel/framework/commit/07d160ac3cc9764d5b429734ffce4fa311385403
             ['* * * * MON-FRI', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-09 00:00:00'), false],
@@ -585,5 +585,20 @@ class CronExpressionTest extends TestCase
         $this->expectExceptionMessage('6 is not a valid position');
 
         $e = CronExpression::factory('0 * * * * ? *');
+    }
+
+    /**
+     * @see https://github.com/dragonmantank/cron-expression/issues/35
+     */
+    public function testMakeDayOfWeekAnOrSometimes()
+    {
+        $cron = CronExpression::factory('30 0 1 * 1');
+        $runs = $cron->getMultipleRunDates(5, date("2019-10-10 23:20:00"), false, true);
+
+        $this->assertSame("2019-10-14 00:30:00", $runs[0]->format('Y-m-d H:i:s'));
+        $this->assertSame("2019-10-21 00:30:00", $runs[1]->format('Y-m-d H:i:s'));
+        $this->assertSame("2019-10-28 00:30:00", $runs[2]->format('Y-m-d H:i:s'));
+        $this->assertSame("2019-11-01 00:30:00", $runs[3]->format('Y-m-d H:i:s'));
+        $this->assertSame("2019-11-04 00:30:00", $runs[4]->format('Y-m-d H:i:s'));
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -192,6 +192,10 @@ class CronExpressionTest extends TestCase
             ['@Weekly', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
             ['@WEEKLY', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
             ['@WeeklY', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
+
+            // Issue #76, DOW and DOM do not support ?
+            ['0 12 * * ?', strtotime('2020-08-20 00:00:00'), strtotime('2020-08-20 12:00:00'), false],
+            ['0 12 ? * *', strtotime('2020-08-20 00:00:00'), strtotime('2020-08-20 12:00:00'), false],
         ];
     }
 

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -611,7 +611,7 @@ class CronExpressionTest extends TestCase
 
     /**
      * Make sure that getNextRunDate() does not add arbitrary minutes
-     * 
+     *
      * @see https://github.com/mtdowling/cron-expression/issues/152
      */
     public function testNextRunDateShouldNotAddMinutes()

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -199,6 +199,10 @@ class CronExpressionTest extends TestCase
             // Issue #76, DOW and DOM do not support ?
             ['0 12 * * ?', strtotime('2020-08-20 00:00:00'), strtotime('2020-08-20 12:00:00'), false],
             ['0 12 ? * *', strtotime('2020-08-20 00:00:00'), strtotime('2020-08-20 12:00:00'), false],
+            ['0-59/59 10 * * *', strtotime('2021-08-25 10:00:00'), strtotime('2021-08-25 10:00:00'), true],
+            ['0-59/59 10 * * *', strtotime('2021-08-25 09:00:00'), strtotime('2021-08-25 10:00:00'), false],
+            ['0-59/59 10 * * *', strtotime('2021-08-25 10:01:00'), strtotime('2021-08-25 10:59:00'), false],
+            ['0-59/65 10 * * *', strtotime('2021-08-25 10:01:00'), strtotime('2021-08-25 10:05:00'), false],
         ];
     }
 

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -172,6 +172,9 @@ class CronExpressionTest extends TestCase
             array('* * * * 5#2', strtotime('2011-07-01 00:00:00'), '2011-07-08 00:00:00', false),
             array('* * * * 5#1', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true),
             array('* * * * 3#4', strtotime('2011-07-01 00:00:00'), '2011-07-27 00:00:00', false),
+
+            // Issue #7, documented example failed
+            ['3-59/15 6-12 */15 1 2-5', strtotime('2017-01-08 00:00:00'), '2017-01-31 06:03:00', false],
         );
     }
 
@@ -440,5 +443,8 @@ class CronExpressionTest extends TestCase
 
         // Issue #125, this is just all sorts of wrong
         $this->assertFalse(CronExpression::isValidExpression('990 14 * * mon-fri0345345'));
+
+        // Issue #7, this was the old documented example that had invalid syntax
+        $this->assertFalse(CronExpression::isValidExpression('3-59/15 2,6-12 */15 1 2-5'));
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -5,6 +5,7 @@ namespace Cron\Tests;
 use Cron\CronExpression;
 use Cron\MonthField;
 use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -228,6 +229,7 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($cron->isDue('now'));
         $this->assertTrue($cron->isDue(new DateTime('now')));
         $this->assertTrue($cron->isDue(date('Y-m-d H:i')));
+        $this->assertTrue($cron->isDue(new DateTimeImmutable('now')));
     }
 
     /**
@@ -405,6 +407,18 @@ class CronExpressionTest extends TestCase
         $this->assertEquals($nextRun, new DateTime("2008-11-23 00:00:00"));
         $nextRun = $cron->getNextRunDate("2008-11-09 00:00:00", 3, true);
         $this->assertEquals($nextRun, new DateTime("2008-11-30 00:00:00"));
+    }
+
+    /**
+     * @covers \Cron\CronExpression::getRunDate
+     */
+    public function testGetRunDateHandlesDifferentDates()
+    {
+        $cron = CronExpression::factory('@weekly');
+        $date = new DateTime("2019-03-10 00:00:00");
+        $this->assertEquals($date, $cron->getNextRunDate("2019-03-03 08:00:00"));
+        $this->assertEquals($date, $cron->getNextRunDate(new DateTime("2019-03-03 08:00:00")));
+        $this->assertEquals($date, $cron->getNextRunDate(new DateTimeImmutable("2019-03-03 08:00:00")));
     }
 
     /**

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -50,11 +50,11 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::__construct
      * @covers \Cron\CronExpression::getExpression
      * @covers \Cron\CronExpression::__toString
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid CRON field value A at position 0
      */
     public function testParsesCronScheduleThrowsAnException(): void
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid CRON field value A at position 0');
         CronExpression::factory('A 1 2 3 4');
     }
 
@@ -94,20 +94,20 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::__construct
      * @covers \Cron\CronExpression::setExpression
      * @covers \Cron\CronExpression::setPart
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCronsWillFail(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         // Only four values
         $cron = CronExpression::factory('* * * 1');
     }
 
     /**
      * @covers \Cron\CronExpression::setPart
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidPartsWillFail(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         // Only four values
         $cron = CronExpression::factory('* * * * *');
         $cron->setPart(1, 'abc');

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -644,7 +644,9 @@ class CronExpressionTest extends TestCase
     public function testNextRunDateShouldNotAddMinutes(): void
     {
         $e = new CronExpression('* 19 * * *');
-        $nextRunDate = $e->getNextRunDate();
+        $tz = new \DateTimeZone("Europe/London");
+        $dt = new \DateTimeImmutable("2021-05-31 18:15:00", $tz);
+        $nextRunDate = $e->getNextRunDate($dt);
 
         $this->assertSame("00", $nextRunDate->format("i"));
     }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -670,4 +670,12 @@ class CronExpressionTest extends TestCase
         $this->assertSame('*', $parts[3]);
         $this->assertSame('1-5', $parts[4]);
     }
+
+    public function testBerlinShouldAdvanceProperlyOverDST()
+    {
+        $e = new CronExpression('0 0 1 * *');
+        $expected = new \DateTime('2022-11-01 00:00:00', new \DateTimeZone('Europe/Berlin'));
+        $next = $e->getNextRunDate(new \DateTime('2022-10-30', new \DateTimeZone('Europe/Berlin')));
+        $this->assertEquals($expected, $next);
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -187,9 +187,11 @@ class CronExpressionTest extends TestCase
             ['* * * * TUE', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-10 00:00:00'), false],
 
             // Issue #60, make sure that casing is less relevant for shortcuts, months, and days
-            ['0 1 15 JUL mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-15 01:00:00'), false],
-            ['0 1 15 jul mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-15 01:00:00'), false],
+            ['0 1 15 JUL mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-01 01:00:00'), false],
+            ['0 1 15 jul mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-01 01:00:00'), false],
             ['@Weekly', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
+            ['@WEEKLY', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
+            ['@WeeklY', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
         ];
     }
 

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -3,6 +3,7 @@
 namespace Cron\Tests;
 
 use Cron\CronExpression;
+use Cron\MonthField;
 use DateTime;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -531,5 +532,29 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($e->isDue(new DateTime('2014-04-07 00:00:00')));
         $e = CronExpression::factory('* 01 * * *');
         $this->assertTrue($e->isDue(new DateTime('2014-04-07 01:00:00')));
+    }
+
+
+    /**
+     * Ranges with large steps should "wrap around" to the appropriate value
+     * cronie allows for steps that are larger than the range of a field, with it wrapping around like a ring buffer. We
+     * should do the same.
+     *
+     * @see https://github.com/dragonmantank/cron-expression/issues/6
+     */
+    public function testRangesWrapAroundWithLargeSteps()
+    {
+        $f = new MonthField();
+        $this->assertTrue($f->validate('*/123'));
+        $this->assertSame([4], $f->getRangeForExpression('*/123', 12));
+
+        $e = CronExpression::factory('* * * */123 *');
+        $this->assertTrue($e->isDue(new DateTime('2014-04-07 00:00:00')));
+
+        $nextRunDate = $e->getNextRunDate(new DateTime('2014-04-07 00:00:00'));
+        $this->assertSame('2014-04-07 00:01:00', $nextRunDate->format('Y-m-d H:i:s'));
+
+        $nextRunDate = $e->getNextRunDate(new DateTime('2014-05-07 00:00:00'));
+        $this->assertSame('2015-04-01 00:00:00', $nextRunDate->format('Y-m-d H:i:s'));
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -175,6 +175,10 @@ class CronExpressionTest extends TestCase
 
             // Issue #7, documented example failed
             ['3-59/15 6-12 */15 1 2-5', strtotime('2017-01-08 00:00:00'), '2017-01-31 06:03:00', false],
+
+            // https://github.com/laravel/framework/commit/07d160ac3cc9764d5b429734ffce4fa311385403
+            ['* * * * MON-FRI', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-09 00:00:00'), false],
+            ['* * * * TUE', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-10 00:00:00'), false],
         );
     }
 
@@ -200,9 +204,17 @@ class CronExpressionTest extends TestCase
         } elseif (is_int($relativeTime)) {
             $relativeTime = date('Y-m-d H:i:s', $relativeTime);
         }
+
+        if (is_string($nextRun)) {
+            $nextRunDate = new DateTime($nextRun);
+        } elseif (is_int($nextRun)) {
+            $nextRunDate = new DateTime();
+            $nextRunDate->setTimestamp($nextRun);
+        }
         $this->assertSame($isDue, $cron->isDue($relativeTime));
         $next = $cron->getNextRunDate($relativeTime, 0, true);
-        $this->assertEquals(new DateTime($nextRun), $next);
+
+        $this->assertEquals($nextRunDate, $next);
     }
 
     /**

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -806,4 +806,11 @@ class CronExpressionTest extends TestCase
 
         CronExpression::unregisterAlias('@daily');
     }
+
+    public function testIssue134ForeachInvalidArgumentOnHours()
+    {
+        $cron = new CronExpression('0 0 1 1 *');
+        $prev = $cron->getPreviousRunDate(new \DateTimeImmutable('2021-09-07T09:36:00Z'));
+        $this->assertEquals(new \DateTime('2021-01-01 00:00:00'), $prev);
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -624,4 +624,19 @@ class CronExpressionTest extends TestCase
 
         $this->assertSame("00", $nextRunDate->format("i"));
     }
+
+    /**
+     * Tests the getParts function.
+     */
+    public function testGetParts()
+    {
+        $e = CronExpression::factory('0 22 * * 1-5');
+        $parts = $e->getParts();
+
+        $this->assertSame('0', $parts[0]);
+        $this->assertSame('22', $parts[1]);
+        $this->assertSame('*', $parts[2]);
+        $this->assertSame('*', $parts[3]);
+        $this->assertSame('1-5', $parts[4]);
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -185,6 +185,11 @@ class CronExpressionTest extends TestCase
             // https://github.com/laravel/framework/commit/07d160ac3cc9764d5b429734ffce4fa311385403
             ['* * * * MON-FRI', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-09 00:00:00'), false],
             ['* * * * TUE', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-10 00:00:00'), false],
+
+            // Issue #60, make sure that casing is less relevant for shortcuts, months, and days
+            ['0 1 15 JUL mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-15 01:00:00'), false],
+            ['0 1 15 jul mon,Wed,FRi', strtotime('2019-11-14 00:00:00'), strtotime('2020-07-15 01:00:00'), false],
+            ['@Weekly', strtotime('2019-11-14 00:00:00'), strtotime('2019-11-17 00:00:00'), false],
         ];
     }
 

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -11,6 +11,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Michael Dowling <mtdowling@gmail.com>
@@ -225,6 +226,7 @@ class CronExpressionTest extends TestCase
             $relativeTime = date('Y-m-d H:i:s', $relativeTime);
         }
 
+        $nextRunDate = new DateTime();
         if (\is_string($nextRun)) {
             $nextRunDate = new DateTime($nextRun);
         } elseif (\is_int($nextRun)) {
@@ -329,18 +331,22 @@ class CronExpressionTest extends TestCase
         $tzServer = new \DateTimeZone('Europe/London');
 
         $dtCurrent = \DateTime::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
+        Assert::isInstanceOf($dtCurrent, DateTime::class);
         $dtPrev = $cron->getPreviousRunDate($dtCurrent, 0, true, $tzCron);
         $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
 
         $dtCurrent = \DateTimeImmutable::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
+        Assert::isInstanceOf($dtCurrent, \DateTimeImmutable::class);
         $dtPrev = $cron->getPreviousRunDate($dtCurrent, 0, true, $tzCron);
         $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
 
         $dtCurrent = \DateTimeImmutable::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
+        Assert::isInstanceOf($dtCurrent, \DateTimeImmutable::class);
         $dtPrev = $cron->getPreviousRunDate($dtCurrent->format('c'), 0, true, $tzCron);
         $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
 
         $dtCurrent = \DateTimeImmutable::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
+        Assert::isInstanceOf($dtCurrent, \DateTimeImmutable::class);
         $dtPrev = $cron->getPreviousRunDate($dtCurrent->format('\\@U'), 0, true, $tzCron);
         $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
     }
@@ -425,7 +431,7 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::getRunDate
      */
-    public function testGetRunDateHandlesDifferentDates()
+    public function testGetRunDateHandlesDifferentDates(): void
     {
         $cron = CronExpression::factory('@weekly');
         $date = new DateTime("2019-03-10 00:00:00");
@@ -437,7 +443,7 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::getRunDate
      */
-    public function testSkipsCurrentDateByDefault()
+    public function testSkipsCurrentDateByDefault(): void
     {
         $cron = CronExpression::factory('* * * * *');
         $current = new DateTime('now');
@@ -601,7 +607,7 @@ class CronExpressionTest extends TestCase
     /**
      * @see https://github.com/dragonmantank/cron-expression/issues/35
      */
-    public function testMakeDayOfWeekAnOrSometimes()
+    public function testMakeDayOfWeekAnOrSometimes(): void
     {
         $cron = CronExpression::factory('30 0 1 * 1');
         $runs = $cron->getMultipleRunDates(5, date("2019-10-10 23:20:00"), false, true);
@@ -618,7 +624,7 @@ class CronExpressionTest extends TestCase
      *
      * @see https://github.com/mtdowling/cron-expression/issues/152
      */
-    public function testNextRunDateShouldNotAddMinutes()
+    public function testNextRunDateShouldNotAddMinutes(): void
     {
         $e = CronExpression::factory('* 19 * * *');
         $nextRunDate = $e->getNextRunDate();

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -678,4 +678,30 @@ class CronExpressionTest extends TestCase
         $next = $e->getNextRunDate(new \DateTime('2022-10-30', new \DateTimeZone('Europe/Berlin')));
         $this->assertEquals($expected, $next);
     }
+
+    /**
+     * Helps validate additional test cases that were failing as part of #131's fix
+     *
+     * @see https://github.com/dragonmantank/cron-expression/issues/131
+     */
+    public function testIssue131()
+    {
+        $e = new CronExpression('* * * * 2');
+        $expected = new \DateTime('2020-10-27 00:00:00');
+        $next = $e->getNextRunDate(new DateTime('2020-10-23 15:31:45'));
+        $this->assertEquals($expected, $next);
+
+        $expected = new \DateTime('2020-10-20 23:59:00');
+        $prev = $e->getPreviousRunDate(new DateTime('2020-10-23 15:31:45'));
+        $this->assertEquals($expected, $prev);
+
+        $e = new CronExpression('15 1 1 9,11 *');
+        $expected = new \DateTime('2022-09-01 01:15:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'));
+        $this->assertEquals($expected, $next);
+
+        $expected = new \DateTime('2021-11-01 01:15:00');
+        $prev = $e->getPreviousRunDate(new \DateTime('2022-08-20 03:44:02'));
+        $this->assertEquals($expected, $prev);
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -820,4 +820,11 @@ class CronExpressionTest extends TestCase
         $prev = $cron->getPreviousRunDate(new \DateTimeImmutable('2021-09-07T09:36:00Z'));
         $this->assertEquals(new \DateTime('2021-01-01 00:00:00'), $prev);
     }
+
+    public function testIssue151ExpressionSupportLW()
+    {
+        $cron = new CronExpression('0 10 LW * *');
+        $this->assertTrue($cron->isDue(new \DateTimeImmutable('2023-08-31 10:00:00')));
+        $this->assertFalse($cron->isDue(new \DateTimeImmutable('2023-08-30 10:00:00')));
+    }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -426,18 +426,6 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::getRunDate
      */
-    public function testGetRunDateHandlesDifferentDates()
-    {
-        $cron = CronExpression::factory('@weekly');
-        $date = new DateTime("2019-03-10 00:00:00");
-        $this->assertEquals($date, $cron->getNextRunDate("2019-03-03 08:00:00"));
-        $this->assertEquals($date, $cron->getNextRunDate(new DateTime("2019-03-03 08:00:00")));
-        $this->assertEquals($date, $cron->getNextRunDate(new DateTimeImmutable("2019-03-03 08:00:00")));
-    }
-
-    /**
-     * @covers \Cron\CronExpression::getRunDate
-     */
     public function testSkipsCurrentDateByDefault()
     {
         $cron = CronExpression::factory('* * * * *');

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -444,7 +444,7 @@ class CronExpressionTest extends TestCase
         // Issue #125, this is just all sorts of wrong
         $this->assertFalse(CronExpression::isValidExpression('990 14 * * mon-fri0345345'));
 
-        // Issue #7, this was the old documented example that had invalid syntax
-        $this->assertFalse(CronExpression::isValidExpression('3-59/15 2,6-12 */15 1 2-5'));
+        // see https://github.com/dragonmantank/cron-expression/issues/5
+        $this->assertTrue(CronExpression::isValidExpression('2,17,35,47 5-7,11-13 * * *'));
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\CronExpression;
@@ -17,7 +19,7 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::factory
      */
-    public function testFactoryRecognizesTemplates()
+    public function testFactoryRecognizesTemplates(): void
     {
         $this->assertSame('0 0 1 1 *', CronExpression::factory('@annually')->getExpression());
         $this->assertSame('0 0 1 1 *', CronExpression::factory('@yearly')->getExpression());
@@ -29,7 +31,7 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::getExpression
      * @covers \Cron\CronExpression::__toString
      */
-    public function testParsesCronSchedule()
+    public function testParsesCronSchedule(): void
     {
         // '2010-09-10 12:00:00'
         $cron = CronExpression::factory('1 2-4 * 4,5,6 */3');
@@ -50,7 +52,7 @@ class CronExpressionTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid CRON field value A at position 0
      */
-    public function testParsesCronScheduleThrowsAnException()
+    public function testParsesCronScheduleThrowsAnException(): void
     {
         CronExpression::factory('A 1 2 3 4');
     }
@@ -59,8 +61,10 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::__construct
      * @covers \Cron\CronExpression::getExpression
      * @dataProvider scheduleWithDifferentSeparatorsProvider
+     *
+     * @param mixed $schedule
      */
-    public function testParsesCronScheduleWithAnySpaceCharsAsSeparators($schedule, array $expected)
+    public function testParsesCronScheduleWithAnySpaceCharsAsSeparators($schedule, array $expected): void
     {
         $cron = CronExpression::factory($schedule);
         $this->assertSame($expected[0], $cron->getExpression(CronExpression::MINUTE));
@@ -71,27 +75,27 @@ class CronExpressionTest extends TestCase
     }
 
     /**
-     * Data provider for testParsesCronScheduleWithAnySpaceCharsAsSeparators
+     * Data provider for testParsesCronScheduleWithAnySpaceCharsAsSeparators.
      *
      * @return array
      */
-    public static function scheduleWithDifferentSeparatorsProvider()
+    public static function scheduleWithDifferentSeparatorsProvider(): array
     {
-        return array(
-            array("*\t*\t*\t*\t*\t", array('*', '*', '*', '*', '*', '*')),
-            array("*  *  *  *  *  ", array('*', '*', '*', '*', '*', '*')),
-            array("* \t * \t * \t * \t * \t", array('*', '*', '*', '*', '*', '*')),
-            array("*\t \t*\t \t*\t \t*\t \t*\t \t", array('*', '*', '*', '*', '*', '*')),
-        );
+        return [
+            ["*\t*\t*\t*\t*\t", ['*', '*', '*', '*', '*', '*']],
+            ['*  *  *  *  *  ', ['*', '*', '*', '*', '*', '*']],
+            ["* \t * \t * \t * \t * \t", ['*', '*', '*', '*', '*', '*']],
+            ["*\t \t*\t \t*\t \t*\t \t*\t \t", ['*', '*', '*', '*', '*', '*']],
+        ];
     }
 
     /**
      * @covers \Cron\CronExpression::__construct
      * @covers \Cron\CronExpression::setExpression
      * @covers \Cron\CronExpression::setPart
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testInvalidCronsWillFail()
+    public function testInvalidCronsWillFail(): void
     {
         // Only four values
         $cron = CronExpression::factory('* * * 1');
@@ -99,9 +103,9 @@ class CronExpressionTest extends TestCase
 
     /**
      * @covers \Cron\CronExpression::setPart
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
-    public function testInvalidPartsWillFail()
+    public function testInvalidPartsWillFail(): void
     {
         // Only four values
         $cron = CronExpression::factory('* * * * *');
@@ -109,70 +113,70 @@ class CronExpressionTest extends TestCase
     }
 
     /**
-     * Data provider for cron schedule
+     * Data provider for cron schedule.
      *
      * @return array
      */
-    public function scheduleProvider()
+    public function scheduleProvider(): array
     {
-        return array(
-            array('*/2 */2 * * *', '2015-08-10 21:47:27', '2015-08-10 22:00:00', false),
-            array('* * * * *', '2015-08-10 21:50:37', '2015-08-10 21:50:00', true),
-            array('* 20,21,22 * * *', '2015-08-10 21:50:00', '2015-08-10 21:50:00', true),
+        return [
+            ['*/2 */2 * * *', '2015-08-10 21:47:27', '2015-08-10 22:00:00', false],
+            ['* * * * *', '2015-08-10 21:50:37', '2015-08-10 21:50:00', true],
+            ['* 20,21,22 * * *', '2015-08-10 21:50:00', '2015-08-10 21:50:00', true],
             // Handles CSV values
-            array('* 20,22 * * *', '2015-08-10 21:50:00', '2015-08-10 22:00:00', false),
+            ['* 20,22 * * *', '2015-08-10 21:50:00', '2015-08-10 22:00:00', false],
             // CSV values can be complex
-            array('7-9 * */9 * *', '2015-08-10 22:02:33', '2015-08-10 22:07:00', false),
+            ['7-9 * */9 * *', '2015-08-10 22:02:33', '2015-08-10 22:07:00', false],
             // 15th minute, of the second hour, every 15 days, in January, every Friday
-            array('1 * * * 7', '2015-08-10 21:47:27', '2015-08-16 00:01:00', false),
+            ['1 * * * 7', '2015-08-10 21:47:27', '2015-08-16 00:01:00', false],
             // Test with exact times
-            array('47 21 * * *', strtotime('2015-08-10 21:47:30'), '2015-08-10 21:47:00', true),
+            ['47 21 * * *', strtotime('2015-08-10 21:47:30'), '2015-08-10 21:47:00', true],
             // Test Day of the week (issue #1)
             // According cron implementation, 0|7 = sunday, 1 => monday, etc
-            array('* * * * 0', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false),
-            array('* * * * 7', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false),
-            array('* * * * 1', strtotime('2011-06-15 23:09:00'), '2011-06-20 00:00:00', false),
+            ['* * * * 0', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false],
+            ['* * * * 7', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false],
+            ['* * * * 1', strtotime('2011-06-15 23:09:00'), '2011-06-20 00:00:00', false],
             // Should return the sunday date as 7 equals 0
-            array('0 0 * * MON,SUN', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false),
-            array('0 0 * * 1,7', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false),
-            array('0 0 * * 0-4', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false),
-            array('0 0 * * 7-4', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false),
-            array('0 0 * * 4-7', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false),
-            array('0 0 * * 7-3', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false),
-            array('0 0 * * 3-7', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false),
-            array('0 0 * * 3-7', strtotime('2011-06-18 23:09:00'), '2011-06-19 00:00:00', false),
+            ['0 0 * * MON,SUN', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false],
+            ['0 0 * * 1,7', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false],
+            ['0 0 * * 0-4', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false],
+            ['0 0 * * 7-4', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false],
+            ['0 0 * * 4-7', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false],
+            ['0 0 * * 7-3', strtotime('2011-06-15 23:09:00'), '2011-06-19 00:00:00', false],
+            ['0 0 * * 3-7', strtotime('2011-06-15 23:09:00'), '2011-06-16 00:00:00', false],
+            ['0 0 * * 3-7', strtotime('2011-06-18 23:09:00'), '2011-06-19 00:00:00', false],
             // Test lists of values and ranges (Abhoryo)
-            array('0 0 * * 2-7', strtotime('2011-06-20 23:09:00'), '2011-06-21 00:00:00', false),
-            array('0 0 * * 2-7', strtotime('2011-06-18 23:09:00'), '2011-06-19 00:00:00', false),
-            array('0 0 * * 4-7', strtotime('2011-07-19 00:00:00'), '2011-07-21 00:00:00', false),
+            ['0 0 * * 2-7', strtotime('2011-06-20 23:09:00'), '2011-06-21 00:00:00', false],
+            ['0 0 * * 2-7', strtotime('2011-06-18 23:09:00'), '2011-06-19 00:00:00', false],
+            ['0 0 * * 4-7', strtotime('2011-07-19 00:00:00'), '2011-07-21 00:00:00', false],
             // Test increments of ranges
-            array('0-12/4 * * * *', strtotime('2011-06-20 12:04:00'), '2011-06-20 12:04:00', true),
-            array('4-59/2 * * * *', strtotime('2011-06-20 12:04:00'), '2011-06-20 12:04:00', true),
-            array('4-59/2 * * * *', strtotime('2011-06-20 12:06:00'), '2011-06-20 12:06:00', true),
-            array('4-59/3 * * * *', strtotime('2011-06-20 12:06:00'), '2011-06-20 12:07:00', false),
+            ['0-12/4 * * * *', strtotime('2011-06-20 12:04:00'), '2011-06-20 12:04:00', true],
+            ['4-59/2 * * * *', strtotime('2011-06-20 12:04:00'), '2011-06-20 12:04:00', true],
+            ['4-59/2 * * * *', strtotime('2011-06-20 12:06:00'), '2011-06-20 12:06:00', true],
+            ['4-59/3 * * * *', strtotime('2011-06-20 12:06:00'), '2011-06-20 12:07:00', false],
             // Test Day of the Week and the Day of the Month (issue #1)
-            array('0 0 1 1 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false),
-            array('0 0 1 JAN 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false),
-            array('0 0 1 * 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false),
+            ['0 0 1 1 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false],
+            ['0 0 1 JAN 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false],
+            ['0 0 1 * 0', strtotime('2011-06-15 23:09:00'), '2012-01-01 00:00:00', false],
             // Test the W day of the week modifier for day of the month field
-            array('0 0 2W * *', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true),
-            array('0 0 1W * *', strtotime('2011-05-01 00:00:00'), '2011-05-02 00:00:00', false),
-            array('0 0 1W * *', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true),
-            array('0 0 3W * *', strtotime('2011-07-01 00:00:00'), '2011-07-04 00:00:00', false),
-            array('0 0 16W * *', strtotime('2011-07-01 00:00:00'), '2011-07-15 00:00:00', false),
-            array('0 0 28W * *', strtotime('2011-07-01 00:00:00'), '2011-07-28 00:00:00', false),
-            array('0 0 30W * *', strtotime('2011-07-01 00:00:00'), '2011-07-29 00:00:00', false),
-            array('0 0 31W * *', strtotime('2011-07-01 00:00:00'), '2011-07-29 00:00:00', false),
+            ['0 0 2W * *', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true],
+            ['0 0 1W * *', strtotime('2011-05-01 00:00:00'), '2011-05-02 00:00:00', false],
+            ['0 0 1W * *', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true],
+            ['0 0 3W * *', strtotime('2011-07-01 00:00:00'), '2011-07-04 00:00:00', false],
+            ['0 0 16W * *', strtotime('2011-07-01 00:00:00'), '2011-07-15 00:00:00', false],
+            ['0 0 28W * *', strtotime('2011-07-01 00:00:00'), '2011-07-28 00:00:00', false],
+            ['0 0 30W * *', strtotime('2011-07-01 00:00:00'), '2011-07-29 00:00:00', false],
+            ['0 0 31W * *', strtotime('2011-07-01 00:00:00'), '2011-07-29 00:00:00', false],
             // Test the last weekday of a month
-            array('* * * * 5L', strtotime('2011-07-01 00:00:00'), '2011-07-29 00:00:00', false),
-            array('* * * * 6L', strtotime('2011-07-01 00:00:00'), '2011-07-30 00:00:00', false),
-            array('* * * * 7L', strtotime('2011-07-01 00:00:00'), '2011-07-31 00:00:00', false),
-            array('* * * * 1L', strtotime('2011-07-24 00:00:00'), '2011-07-25 00:00:00', false),
-            array('* * * 1 5L', strtotime('2011-12-25 00:00:00'), '2012-01-27 00:00:00', false),
+            ['* * * * 5L', strtotime('2011-07-01 00:00:00'), '2011-07-29 00:00:00', false],
+            ['* * * * 6L', strtotime('2011-07-01 00:00:00'), '2011-07-30 00:00:00', false],
+            ['* * * * 7L', strtotime('2011-07-01 00:00:00'), '2011-07-31 00:00:00', false],
+            ['* * * * 1L', strtotime('2011-07-24 00:00:00'), '2011-07-25 00:00:00', false],
+            ['* * * 1 5L', strtotime('2011-12-25 00:00:00'), '2012-01-27 00:00:00', false],
             // Test the hash symbol for the nth weekday of a given month
-            array('* * * * 5#2', strtotime('2011-07-01 00:00:00'), '2011-07-08 00:00:00', false),
-            array('* * * * 5#1', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true),
-            array('* * * * 3#4', strtotime('2011-07-01 00:00:00'), '2011-07-27 00:00:00', false),
+            ['* * * * 5#2', strtotime('2011-07-01 00:00:00'), '2011-07-08 00:00:00', false],
+            ['* * * * 5#1', strtotime('2011-07-01 00:00:00'), '2011-07-01 00:00:00', true],
+            ['* * * * 3#4', strtotime('2011-07-01 00:00:00'), '2011-07-27 00:00:00', false],
 
             // Issue #7, documented example failed
             ['3-59/15 6-12 */15 1 2-5', strtotime('2017-01-08 00:00:00'), '2017-01-31 06:03:00', false],
@@ -180,7 +184,7 @@ class CronExpressionTest extends TestCase
             // https://github.com/laravel/framework/commit/07d160ac3cc9764d5b429734ffce4fa311385403
             ['* * * * MON-FRI', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-09 00:00:00'), false],
             ['* * * * TUE', strtotime('2017-01-08 00:00:00'), strtotime('2017-01-10 00:00:00'), false],
-        );
+        ];
     }
 
     /**
@@ -193,22 +197,25 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\MonthField
      * @covers \Cron\CronExpression::getRunDate
      * @dataProvider scheduleProvider
+     *
+     * @param mixed $schedule
+     * @param mixed $relativeTime
+     * @param mixed $nextRun
+     * @param mixed $isDue
      */
-    public function testDeterminesIfCronIsDue($schedule, $relativeTime, $nextRun, $isDue)
+    public function testDeterminesIfCronIsDue($schedule, $relativeTime, $nextRun, $isDue): void
     {
-        $relativeTimeString = is_int($relativeTime) ? date('Y-m-d H:i:s', $relativeTime) : $relativeTime;
-
         // Test next run date
         $cron = CronExpression::factory($schedule);
-        if (is_string($relativeTime)) {
+        if (\is_string($relativeTime)) {
             $relativeTime = new DateTime($relativeTime);
-        } elseif (is_int($relativeTime)) {
+        } elseif (\is_int($relativeTime)) {
             $relativeTime = date('Y-m-d H:i:s', $relativeTime);
         }
 
-        if (is_string($nextRun)) {
+        if (\is_string($nextRun)) {
             $nextRunDate = new DateTime($nextRun);
-        } elseif (is_int($nextRun)) {
+        } elseif (\is_int($nextRun)) {
             $nextRunDate = new DateTime();
             $nextRunDate->setTimestamp($nextRun);
         }
@@ -221,7 +228,7 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::isDue
      */
-    public function testIsDueHandlesDifferentDates()
+    public function testIsDueHandlesDifferentDates(): void
     {
         $cron = CronExpression::factory('* * * * *');
         $this->assertTrue($cron->isDue());
@@ -233,7 +240,7 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::isDue
      */
-    public function testIsDueHandlesDifferentDefaultTimezones()
+    public function testIsDueHandlesDifferentDefaultTimezones(): void
     {
         $originalTimezone = date_default_timezone_get();
         $cron = CronExpression::factory('0 15 * * 3'); //Wednesday at 15:00
@@ -260,7 +267,7 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::isDue
      */
-    public function testIsDueHandlesDifferentSuppliedTimezones()
+    public function testIsDueHandlesDifferentSuppliedTimezones(): void
     {
         $cron = CronExpression::factory('0 15 * * 3'); //Wednesday at 15:00
         $date = '2014-01-01 15:00'; //Wednesday
@@ -278,16 +285,16 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($cron->isDue(new DateTime($date, new DateTimeZone('Asia/Tokyo')), 'Asia/Tokyo'));
     }
 
-   /**
-     * @covers Cron\CronExpression::isDue
+    /**
+     * @covers \Cron\CronExpression::isDue
      */
-    public function testIsDueHandlesDifferentTimezonesAsArgument()
+    public function testIsDueHandlesDifferentTimezonesAsArgument(): void
     {
-        $cron      = CronExpression::factory('0 15 * * 3'); //Wednesday at 15:00
-        $date      = '2014-01-01 15:00'; //Wednesday
-        $utc       = new \DateTimeZone('UTC');
+        $cron = CronExpression::factory('0 15 * * 3'); //Wednesday at 15:00
+        $date = '2014-01-01 15:00'; //Wednesday
+        $utc = new \DateTimeZone('UTC');
         $amsterdam = new \DateTimeZone('Europe/Amsterdam');
-        $tokyo     = new \DateTimeZone('Asia/Tokyo');
+        $tokyo = new \DateTimeZone('Asia/Tokyo');
         $this->assertTrue($cron->isDue(new DateTime($date, $utc), 'UTC'));
         $this->assertFalse($cron->isDue(new DateTime($date, $amsterdam), 'UTC'));
         $this->assertFalse($cron->isDue(new DateTime($date, $tokyo), 'UTC'));
@@ -300,37 +307,35 @@ class CronExpressionTest extends TestCase
     }
 
     /**
-     * @covers Cron\CronExpression::isDue
+     * @covers \Cron\CronExpression::isDue
      */
-    public function testRecognisesTimezonesAsPartOfDateTime()
+    public function testRecognisesTimezonesAsPartOfDateTime(): void
     {
-        $cron = CronExpression::factory("0 7 * * *");
-        $tzCron = "America/New_York";
-        $tzServer = new \DateTimeZone("Europe/London");
+        $cron = CronExpression::factory('0 7 * * *');
+        $tzCron = 'America/New_York';
+        $tzServer = new \DateTimeZone('Europe/London');
 
-        $dtCurrent = \DateTime::createFromFormat("!Y-m-d H:i:s", "2017-10-17 10:00:00", $tzServer);
+        $dtCurrent = \DateTime::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
         $dtPrev = $cron->getPreviousRunDate($dtCurrent, 0, true, $tzCron);
-        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format("U \: c \: e"));
+        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
 
-        $dtCurrent = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2017-10-17 10:00:00", $tzServer);
+        $dtCurrent = \DateTimeImmutable::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
         $dtPrev = $cron->getPreviousRunDate($dtCurrent, 0, true, $tzCron);
-        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format("U \: c \: e"));
+        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
 
-        $dtCurrent = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2017-10-17 10:00:00", $tzServer);
-        $dtPrev = $cron->getPreviousRunDate($dtCurrent->format("c"), 0, true, $tzCron);
-        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format("U \: c \: e"));
+        $dtCurrent = \DateTimeImmutable::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
+        $dtPrev = $cron->getPreviousRunDate($dtCurrent->format('c'), 0, true, $tzCron);
+        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
 
-        $dtCurrent = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2017-10-17 10:00:00", $tzServer);
-        $dtPrev = $cron->getPreviousRunDate($dtCurrent->format("\@U"), 0, true, $tzCron);
-        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format("U \: c \: e"));
-
+        $dtCurrent = \DateTimeImmutable::createFromFormat('!Y-m-d H:i:s', '2017-10-17 10:00:00', $tzServer);
+        $dtPrev = $cron->getPreviousRunDate($dtCurrent->format('\\@U'), 0, true, $tzCron);
+        $this->assertEquals('1508151600 : 2017-10-16T07:00:00-04:00 : America/New_York', $dtPrev->format('U \\: c \\: e'));
     }
-
 
     /**
      * @covers \Cron\CronExpression::getPreviousRunDate
      */
-    public function testCanGetPreviousRunDates()
+    public function testCanGetPreviousRunDates(): void
     {
         $cron = CronExpression::factory('* * * * *');
         $next = $cron->getNextRunDate('now');
@@ -351,26 +356,27 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::getMultipleRunDates
      */
-    public function testProvidesMultipleRunDates()
+    public function testProvidesMultipleRunDates(): void
     {
         $cron = CronExpression::factory('*/2 * * * *');
-        $this->assertEquals(array(
+        $this->assertEquals([
             new DateTime('2008-11-09 00:00:00'),
             new DateTime('2008-11-09 00:02:00'),
             new DateTime('2008-11-09 00:04:00'),
-            new DateTime('2008-11-09 00:06:00')
-        ), $cron->getMultipleRunDates(4, '2008-11-09 00:00:00', false, true));
+            new DateTime('2008-11-09 00:06:00'),
+        ], $cron->getMultipleRunDates(4, '2008-11-09 00:00:00', false, true));
     }
 
     /**
      * @covers \Cron\CronExpression::getMultipleRunDates
      * @covers \Cron\CronExpression::setMaxIterationCount
      */
-    public function testProvidesMultipleRunDatesForTheFarFuture() {
+    public function testProvidesMultipleRunDatesForTheFarFuture(): void
+    {
         // Fails with the default 1000 iteration limit
         $cron = CronExpression::factory('0 0 12 1 *');
         $cron->setMaxIterationCount(2000);
-        $this->assertEquals(array(
+        $this->assertEquals([
             new DateTime('2016-01-12 00:00:00'),
             new DateTime('2017-01-12 00:00:00'),
             new DateTime('2018-01-12 00:00:00'),
@@ -380,37 +386,33 @@ class CronExpressionTest extends TestCase
             new DateTime('2022-01-12 00:00:00'),
             new DateTime('2023-01-12 00:00:00'),
             new DateTime('2024-01-12 00:00:00'),
-        ), $cron->getMultipleRunDates(9, '2015-04-28 00:00:00', false, true));
+        ], $cron->getMultipleRunDates(9, '2015-04-28 00:00:00', false, true));
     }
 
     /**
      * @covers \Cron\CronExpression
      */
-    public function testCanIterateOverNextRuns()
+    public function testCanIterateOverNextRuns(): void
     {
         $cron = CronExpression::factory('@weekly');
-        $nextRun = $cron->getNextRunDate("2008-11-09 08:00:00");
-        $this->assertEquals($nextRun, new DateTime("2008-11-16 00:00:00"));
-
-        // true is cast to 1
-        $nextRun = $cron->getNextRunDate("2008-11-09 00:00:00", true, true);
-        $this->assertEquals($nextRun, new DateTime("2008-11-16 00:00:00"));
+        $nextRun = $cron->getNextRunDate('2008-11-09 08:00:00');
+        $this->assertEquals($nextRun, new DateTime('2008-11-16 00:00:00'));
 
         // You can iterate over them
-        $nextRun = $cron->getNextRunDate($cron->getNextRunDate("2008-11-09 00:00:00", 1, true), 1, true);
-        $this->assertEquals($nextRun, new DateTime("2008-11-23 00:00:00"));
+        $nextRun = $cron->getNextRunDate($cron->getNextRunDate('2008-11-09 00:00:00', 1, true), 1, true);
+        $this->assertEquals($nextRun, new DateTime('2008-11-23 00:00:00'));
 
         // You can skip more than one
-        $nextRun = $cron->getNextRunDate("2008-11-09 00:00:00", 2, true);
-        $this->assertEquals($nextRun, new DateTime("2008-11-23 00:00:00"));
-        $nextRun = $cron->getNextRunDate("2008-11-09 00:00:00", 3, true);
-        $this->assertEquals($nextRun, new DateTime("2008-11-30 00:00:00"));
+        $nextRun = $cron->getNextRunDate('2008-11-09 00:00:00', 2, true);
+        $this->assertEquals($nextRun, new DateTime('2008-11-23 00:00:00'));
+        $nextRun = $cron->getNextRunDate('2008-11-09 00:00:00', 3, true);
+        $this->assertEquals($nextRun, new DateTime('2008-11-30 00:00:00'));
     }
 
     /**
      * @covers \Cron\CronExpression::getRunDate
      */
-    public function testSkipsCurrentDateByDefault()
+    public function testSkipsCurrentDateByDefault(): void
     {
         $cron = CronExpression::factory('* * * * *');
         $current = new DateTime('now');
@@ -423,7 +425,7 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::getRunDate
      * @ticket 7
      */
-    public function testStripsForSeconds()
+    public function testStripsForSeconds(): void
     {
         $cron = CronExpression::factory('* * * * *');
         $current = new DateTime('2011-09-27 10:10:54');
@@ -433,13 +435,13 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::getRunDate
      */
-    public function testFixesPhpBugInDateIntervalMonth()
+    public function testFixesPhpBugInDateIntervalMonth(): void
     {
         $cron = CronExpression::factory('0 0 27 JAN *');
         $this->assertSame('2011-01-27 00:00:00', $cron->getPreviousRunDate('2011-08-22 00:00:00')->format('Y-m-d H:i:s'));
     }
 
-    public function testIssue29()
+    public function testIssue29(): void
     {
         $cron = CronExpression::factory('@weekly');
         $this->assertSame(
@@ -451,7 +453,8 @@ class CronExpressionTest extends TestCase
     /**
      * @see https://github.com/mtdowling/cron-expression/issues/20
      */
-    public function testIssue20() {
+    public function testIssue20(): void
+    {
         $e = CronExpression::factory('* * * * MON#1');
         $this->assertTrue($e->isDue(new DateTime('2014-04-07 00:00:00')));
         $this->assertFalse($e->isDue(new DateTime('2014-04-14 00:00:00')));
@@ -471,9 +474,9 @@ class CronExpressionTest extends TestCase
     /**
      * @covers \Cron\CronExpression::getRunDate
      */
-    public function testKeepOriginalTime()
+    public function testKeepOriginalTime(): void
     {
-        $now = new \DateTime;
+        $now = new \DateTime();
         $strNow = $now->format(DateTime::ISO8601);
         $cron = CronExpression::factory('0 0 * * *');
         $cron->getPreviousRunDate($now);
@@ -487,7 +490,7 @@ class CronExpressionTest extends TestCase
      * @covers \Cron\CronExpression::setExpression
      * @covers \Cron\CronExpression::setPart
      */
-    public function testValidationWorks()
+    public function testValidationWorks(): void
     {
         // Invalid. Only four values
         $this->assertFalse(CronExpression::isValidExpression('* * * 1'));
@@ -495,13 +498,13 @@ class CronExpressionTest extends TestCase
         $this->assertTrue(CronExpression::isValidExpression('* * * * 1'));
 
         // Issue #156, 13 is an invalid month
-        $this->assertFalse(CronExpression::isValidExpression("* * * 13 * "));
+        $this->assertFalse(CronExpression::isValidExpression('* * * 13 * '));
 
         // Issue #155, 90 is an invalid second
         $this->assertFalse(CronExpression::isValidExpression('90 * * * *'));
 
         // Issue #154, 24 is an invalid hour
-        $this->assertFalse(CronExpression::isValidExpression("0 24 1 12 0"));
+        $this->assertFalse(CronExpression::isValidExpression('0 24 1 12 0'));
 
         // Issue #125, this is just all sorts of wrong
         $this->assertFalse(CronExpression::isValidExpression('990 14 * * mon-fri0345345'));
@@ -512,11 +515,11 @@ class CronExpressionTest extends TestCase
 
     /**
      * Makes sure that 00 is considered a valid value for 0-based fields
-     * cronie allows numbers with a leading 0, so adding support for this as well
+     * cronie allows numbers with a leading 0, so adding support for this as well.
      *
      * @see https://github.com/dragonmantank/cron-expression/issues/12
      */
-    public function testDoubleZeroIsValid()
+    public function testDoubleZeroIsValid(): void
     {
         $this->assertTrue(CronExpression::isValidExpression('00 * * * *'));
         $this->assertTrue(CronExpression::isValidExpression('01 * * * *'));
@@ -534,7 +537,6 @@ class CronExpressionTest extends TestCase
         $this->assertTrue($e->isDue(new DateTime('2014-04-07 01:00:00')));
     }
 
-
     /**
      * Ranges with large steps should "wrap around" to the appropriate value
      * cronie allows for steps that are larger than the range of a field, with it wrapping around like a ring buffer. We
@@ -542,7 +544,7 @@ class CronExpressionTest extends TestCase
      *
      * @see https://github.com/dragonmantank/cron-expression/issues/6
      */
-    public function testRangesWrapAroundWithLargeSteps()
+    public function testRangesWrapAroundWithLargeSteps(): void
     {
         $f = new MonthField();
         $this->assertTrue($f->validate('*/123'));
@@ -559,14 +561,14 @@ class CronExpressionTest extends TestCase
     }
 
     /**
-     * When there is an issue with a field, we should report the human readable position
+     * When there is an issue with a field, we should report the human readable position.
      *
      * @see https://github.com/dragonmantank/cron-expression/issues/29
      */
-    public function testFieldPositionIsHumanAdjusted()
+    public function testFieldPositionIsHumanAdjusted(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("6 is not a valid position");
+        $this->expectExceptionMessage('6 is not a valid position');
         $e = CronExpression::factory('0 * * * * ? *');
     }
 }

--- a/tests/Cron/CronExpressionTest.php
+++ b/tests/Cron/CronExpressionTest.php
@@ -724,6 +724,31 @@ class CronExpressionTest extends TestCase
         $expected = new \DateTime('2021-12-31 20:00:00');
         $prev = $e->getPreviousRunDate(new \DateTime('2022-08-20 03:44:02'), 1);
         $this->assertEquals($expected, $prev);
+
+        $e = new CronExpression('0 20 L 6,12 0-6');
+        $expected = new \DateTime('2022-12-01 20:00:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'));
+        $this->assertEquals($expected, $next);
+
+        $e = new CronExpression('0 20 L 6,12 0-6');
+        $expected = new \DateTime('2022-12-02 20:00:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'), 1);
+        $this->assertEquals($expected, $next);
+
+        $e = new CronExpression('0 20 L 6,12 0-6');
+        $expected = new \DateTime('2022-12-03 20:00:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'), 2);
+        $this->assertEquals($expected, $next);
+
+        $e = new CronExpression('0 20 * 6,12 *');
+        $expected = new \DateTime('2022-12-01 20:00:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'));
+        $this->assertEquals($expected, $next);
+
+        $e = new CronExpression('0 20 * 6,12 *');
+        $expected = new \DateTime('2022-12-06 20:00:00');
+        $next = $e->getNextRunDate(new \DateTime('2022-08-20 03:44:02'), 5);
+        $this->assertEquals($expected, $next);
     }
 
     public function testItCanRegisterAnValidExpression(): void

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\DayOfMonthField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +34,7 @@ class DayOfMonthFieldTest extends TestCase
     {
         $f = new DayOfMonthField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
     }
 
     /**
@@ -48,6 +50,17 @@ class DayOfMonthFieldTest extends TestCase
         $d = new DateTime('2011-03-15 11:15:00');
         $f->increment($d, true);
         $this->assertSame('2011-03-14 23:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\DayOfMonthField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new DayOfMonthField();
+        $f->increment($d);
+        $this->assertSame('2011-03-16 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -21,6 +21,7 @@ class DayOfMonthFieldTest extends TestCase
         $this->assertTrue($f->validate('*'));
         $this->assertTrue($f->validate('L'));
         $this->assertTrue($f->validate('5W'));
+        $this->assertTrue($f->validate('01'));
         $this->assertFalse($f->validate('5W,L'));
         $this->assertFalse($f->validate('1.'));
     }

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -36,8 +36,8 @@ class DayOfMonthFieldTest extends TestCase
     public function testChecksIfSatisfied(): void
     {
         $f = new DayOfMonthField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
     /**

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -115,4 +115,10 @@ class DayOfMonthFieldTest extends TestCase
         $f->increment($d, true);
         $this->assertSame("2021-03-27 23:59:00", $d->format("Y-m-d H:i:s"));
     }
+
+    public function testIssue151DOMFieldSupportLW()
+    {
+        $f = new DayOfMonthField();
+        $this->assertTrue($f->validate('LW'));
+    }
 }

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -24,6 +24,7 @@ class DayOfMonthFieldTest extends TestCase
         $this->assertTrue($f->validate('*'));
         $this->assertTrue($f->validate('L'));
         $this->assertTrue($f->validate('5W'));
+        $this->assertTrue($f->validate('?'));
         $this->assertTrue($f->validate('01'));
         $this->assertFalse($f->validate('5W,L'));
         $this->assertFalse($f->validate('1.'));

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -17,7 +17,7 @@ class DayOfMonthFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfMonthField::validate
      */
-    public function testValidatesField()
+    public function testValidatesField(): void
     {
         $f = new DayOfMonthField();
         $this->assertTrue($f->validate('1'));
@@ -33,7 +33,7 @@ class DayOfMonthFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfMonthField::isSatisfiedBy
      */
-    public function testChecksIfSatisfied()
+    public function testChecksIfSatisfied(): void
     {
         $f = new DayOfMonthField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
@@ -43,7 +43,7 @@ class DayOfMonthFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfMonthField::increment
      */
-    public function testIncrementsDate()
+    public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
         $f = new DayOfMonthField();
@@ -58,7 +58,7 @@ class DayOfMonthFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfMonthField::increment
      */
-    public function testIncrementsDateTimeImmutable()
+    public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
         $f = new DayOfMonthField();
@@ -72,7 +72,7 @@ class DayOfMonthFieldTest extends TestCase
      *
      * @since 2017-01-22
      */
-    public function testDoesNotAccept0Date()
+    public function testDoesNotAccept0Date(): void
     {
         $f = new DayOfMonthField();
         $this->assertFalse($f->validate('0'));

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\DayOfMonthField;
@@ -52,13 +54,13 @@ class DayOfMonthFieldTest extends TestCase
 
     /**
      * Day of the month cannot accept a 0 value, it must be between 1 and 31
-     * See Github issue #120
+     * See Github issue #120.
      *
      * @since 2017-01-22
      */
     public function testDoesNotAccept0Date()
     {
         $f = new DayOfMonthField();
-        $this->assertFalse($f->validate(0));
+        $this->assertFalse($f->validate('0'));
     }
 }

--- a/tests/Cron/DayOfMonthFieldTest.php
+++ b/tests/Cron/DayOfMonthFieldTest.php
@@ -77,4 +77,42 @@ class DayOfMonthFieldTest extends TestCase
         $f = new DayOfMonthField();
         $this->assertFalse($f->validate('0'));
     }
+
+    /**
+     * @covers \Cron\MinutesField::increment
+     */
+    public function testIncrementAcrossDstChangeBerlin(): void
+    {
+        $tz = new \DateTimeZone("Europe/Berlin");
+        $d = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-28 01:59:00", $tz);
+        $f = new DayOfMonthField();
+        $f->increment($d);
+        $this->assertSame("2021-03-29 00:00:00", $d->format("Y-m-d H:i:s"));
+
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 23:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-27 23:59:00", $d->format("Y-m-d H:i:s"));
+    }
+
+    /**
+     * @covers \Cron\MinutesField::increment
+     */
+    public function testIncrementAcrossDstChangeLondon(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $d = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-28 00:59:00", $tz);
+        $f = new DayOfMonthField();
+        $f->increment($d);
+        $this->assertSame("2021-03-29 00:00:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d);
+        $this->assertSame("2021-03-30 00:00:00", $d->format("Y-m-d H:i:s"));
+
+        $f->increment($d, true);
+        $this->assertSame("2021-03-29 23:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 23:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-27 23:59:00", $d->format("Y-m-d H:i:s"));
+    }
 }

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -114,4 +114,14 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertFalse($f->validate('*-'));
         $this->assertFalse($f->validate(',-'));
     }
+
+    /**
+     * @see https://github.com/laravel/framework/commit/07d160ac3cc9764d5b429734ffce4fa311385403
+     */
+    public function testLiteralsExpandProperly()
+    {
+        $f = new DayOfWeekField();
+        $this->assertTrue($f->validate('MON-FRI'));
+        $this->assertSame([1,2,3,4,5], $f->getRangeForExpression('MON-FRI', 7));
+    }
 }

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -18,6 +18,8 @@ class DayOfWeekFieldTest extends TestCase
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->validate('1'));
+        $this->assertTrue($f->validate('01'));
+        $this->assertTrue($f->validate('00'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
         $this->assertTrue($f->validate('SUN-2'));

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -37,8 +37,8 @@ class DayOfWeekFieldTest extends TestCase
     public function testChecksIfSatisfied(): void
     {
         $f = new DayOfWeekField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
     /**
@@ -75,7 +75,7 @@ class DayOfWeekFieldTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Weekday must be a value between 0 and 7. 12 given');
         $f = new DayOfWeekField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '12#1'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '12#1', false));
     }
 
     /**
@@ -86,7 +86,7 @@ class DayOfWeekFieldTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('There are never more than 5 or less than 1 of a given weekday in a month');
         $f = new DayOfWeekField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '3#6'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '3#6', false));
     }
 
     /**
@@ -111,13 +111,13 @@ class DayOfWeekFieldTest extends TestCase
     public function testHandlesZeroAndSevenDayOfTheWeekValues(): void
     {
         $f = new DayOfWeekField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2011-09-04 00:00:00'), '0-2'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2011-09-04 00:00:00'), '6-0'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2011-09-04 00:00:00'), '0-2', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2011-09-04 00:00:00'), '6-0', false));
 
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), 'SUN'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), 'SUN#3'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), '0#3'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), '7#3'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), 'SUN', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), 'SUN#3', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), '0#3', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2014-04-20 00:00:00'), '7#3', false));
     }
 
     /**
@@ -126,10 +126,10 @@ class DayOfWeekFieldTest extends TestCase
     public function testHandlesLastWeekdayOfTheMonth(): void
     {
         $f = new DayOfWeekField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), 'FRIL'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), '5L'));
-        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), 'FRIL'));
-        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), '5L'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), 'FRIL', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), '5L', false));
+        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), 'FRIL', false));
+        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), '5L', false));
     }
 
     /**

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -7,6 +7,7 @@ namespace Cron\Tests;
 use Cron\DayOfWeekField;
 use DateTime;
 use DateTimeImmutable;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -67,22 +68,22 @@ class DayOfWeekFieldTest extends TestCase
 
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Weekday must be a value between 0 and 7. 12 given
      */
     public function testValidatesHashValueWeekday()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Weekday must be a value between 0 and 7. 12 given');
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '12#1'));
     }
 
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage There are never more than 5 or less than 1 of a given weekday in a month
      */
     public function testValidatesHashValueNth()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There are never more than 5 or less than 1 of a given weekday in a month');
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '3#6'));
     }

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -25,6 +25,7 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('00'));
         $this->assertTrue($f->validate('*'));
+        $this->assertTrue($f->validate('?'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
         $this->assertTrue($f->validate('SUN-2'));
         $this->assertFalse($f->validate('1.'));

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -169,5 +169,6 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->validate('MON'));
         $this->assertTrue($f->validate('Mon'));
         $this->assertTrue($f->validate('mon'));
+        $this->assertTrue($f->validate('Mon,Wed,Fri'));
     }
 }

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\DayOfWeekField;
@@ -52,7 +54,7 @@ class DayOfWeekFieldTest extends TestCase
 
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Weekday must be a value between 0 and 7. 12 given
      */
     public function testValidatesHashValueWeekday()
@@ -63,7 +65,7 @@ class DayOfWeekFieldTest extends TestCase
 
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage There are never more than 5 or less than 1 of a given weekday in a month
      */
     public function testValidatesHashValueNth()
@@ -118,7 +120,8 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @see https://github.com/mtdowling/cron-expression/issues/47
      */
-    public function testIssue47() {
+    public function testIssue47()
+    {
         $f = new DayOfWeekField();
         $this->assertFalse($f->validate('mon,'));
         $this->assertFalse($f->validate('mon-'));
@@ -136,6 +139,6 @@ class DayOfWeekFieldTest extends TestCase
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->validate('MON-FRI'));
-        $this->assertSame([1,2,3,4,5], $f->getRangeForExpression('MON-FRI', 7));
+        $this->assertSame([1, 2, 3, 4, 5], $f->getRangeForExpression('MON-FRI', 7));
     }
 }

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -18,7 +18,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::validate
      */
-    public function testValidatesField()
+    public function testValidatesField(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->validate('1'));
@@ -34,7 +34,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
      */
-    public function testChecksIfSatisfied()
+    public function testChecksIfSatisfied(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
@@ -44,7 +44,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::increment
      */
-    public function testIncrementsDate()
+    public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
         $f = new DayOfWeekField();
@@ -59,7 +59,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::increment
      */
-    public function testIncrementsDateTimeImmutable()
+    public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
         $f = new DayOfWeekField();
@@ -70,7 +70,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
      */
-    public function testValidatesHashValueWeekday()
+    public function testValidatesHashValueWeekday(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Weekday must be a value between 0 and 7. 12 given');
@@ -81,7 +81,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
      */
-    public function testValidatesHashValueNth()
+    public function testValidatesHashValueNth(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('There are never more than 5 or less than 1 of a given weekday in a month');
@@ -92,7 +92,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::validate
      */
-    public function testValidateWeekendHash()
+    public function testValidateWeekendHash(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->validate('MON#1'));
@@ -108,7 +108,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
      */
-    public function testHandlesZeroAndSevenDayOfTheWeekValues()
+    public function testHandlesZeroAndSevenDayOfTheWeekValues(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime('2011-09-04 00:00:00'), '0-2'));
@@ -123,7 +123,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @covers \Cron\DayOfWeekField::isSatisfiedBy
      */
-    public function testHandlesLastWeekdayOfTheMonth()
+    public function testHandlesLastWeekdayOfTheMonth(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), 'FRIL'));
@@ -135,7 +135,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @see https://github.com/mtdowling/cron-expression/issues/47
      */
-    public function testIssue47()
+    public function testIssue47(): void
     {
         $f = new DayOfWeekField();
         $this->assertFalse($f->validate('mon,'));
@@ -150,7 +150,7 @@ class DayOfWeekFieldTest extends TestCase
     /**
      * @see https://github.com/laravel/framework/commit/07d160ac3cc9764d5b429734ffce4fa311385403
      */
-    public function testLiteralsExpandProperly()
+    public function testLiteralsExpandProperly(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->validate('MON-FRI'));
@@ -164,7 +164,7 @@ class DayOfWeekFieldTest extends TestCase
      * @since 2019-07-29
      * @see https://github.com/dragonmantank/cron-expression/issues/24
      */
-    public function testLiteralsIgnoreCasingProperly()
+    public function testLiteralsIgnoreCasingProperly(): void
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->validate('MON'));

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -154,4 +154,19 @@ class DayOfWeekFieldTest extends TestCase
         $this->assertTrue($f->validate('MON-FRI'));
         $this->assertSame([1, 2, 3, 4, 5], $f->getRangeForExpression('MON-FRI', 7));
     }
+
+    /**
+     * Incoming literals should ignore case
+     *
+     * @author Chris Tankersley <chris@ctankersley.com?
+     * @since 2019-07-29
+     * @see https://github.com/dragonmantank/cron-expression/issues/24
+     */
+    public function testLiteralsIgnoreCasingProperly()
+    {
+        $f = new DayOfWeekField();
+        $this->assertTrue($f->validate('MON'));
+        $this->assertTrue($f->validate('Mon'));
+        $this->assertTrue($f->validate('mon'));
+    }
 }

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -104,6 +104,18 @@ class DayOfWeekFieldTest extends TestCase
     }
 
     /**
+     * @covers \Cron\DayOfWeekField::isSatisfiedBy
+     */
+    public function testHandlesLastWeekdayOfTheMonth()
+    {
+        $f = new DayOfWeekField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), 'FRIL'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime('2018-12-28 00:00:00'), '5L'));
+        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), 'FRIL'));
+        $this->assertFalse($f->isSatisfiedBy(new DateTime('2018-12-21 00:00:00'), '5L'));
+    }
+
+    /**
      * @see https://github.com/mtdowling/cron-expression/issues/47
      */
     public function testIssue47() {

--- a/tests/Cron/DayOfWeekFieldTest.php
+++ b/tests/Cron/DayOfWeekFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\DayOfWeekField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +34,7 @@ class DayOfWeekFieldTest extends TestCase
     {
         $f = new DayOfWeekField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
     }
 
     /**
@@ -48,6 +50,17 @@ class DayOfWeekFieldTest extends TestCase
         $d = new DateTime('2011-03-15 11:15:00');
         $f->increment($d, true);
         $this->assertSame('2011-03-14 23:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\DayOfWeekField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new DayOfWeekField();
+        $f->increment($d);
+        $this->assertSame('2011-03-16 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/DaylightSavingsTest.php
+++ b/tests/Cron/DaylightSavingsTest.php
@@ -111,6 +111,11 @@ class DaylightSavingsTest extends TestCase
         $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
     }
 
+    /**
+     * Skip due to PHP 8.1 date instabilities.
+     * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
+     * @requires PHP <= 8.0.22
+     */
     public function testOffsetDecrementsNextRunDateAllowCurrent(): void
     {
         $tz = new \DateTimeZone("Europe/London");
@@ -144,6 +149,9 @@ class DaylightSavingsTest extends TestCase
     /**
      * The fact that crons will run twice using this setup is expected.
      * This can be avoided by using disallowing the current date or with additional checks outside this library
+     * Skip due to PHP 8.1 date instabilities.
+     * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
+     * @requires PHP <= 8.0.22
      */
     public function testOffsetDecrementsNextRunDateDisallowCurrent(): void
     {
@@ -228,6 +236,11 @@ class DaylightSavingsTest extends TestCase
         }
     }
 
+    /**
+     * Skip due to PHP 8.1 date instabilities.
+     * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
+     * @requires PHP <= 8.0.22
+     */
     public function testOffsetDecrementsMultipleRunDates(): void
     {
         $expression = "0 1 * * 0";
@@ -315,6 +328,11 @@ class DaylightSavingsTest extends TestCase
         }
     }
 
+    /**
+     * Skip due to PHP 8.1 date instabilities.
+     * For further references, see https://github.com/dragonmantank/cron-expression/issues/133
+     * @requires PHP <= 8.0.22
+     */
     public function testOffsetDecrementsEveryOtherHour(): void
     {
         $expression = "0 */2 * * *";

--- a/tests/Cron/DaylightSavingsTest.php
+++ b/tests/Cron/DaylightSavingsTest.php
@@ -1,0 +1,438 @@
+<?php
+declare(strict_types=1);
+
+namespace Cron\Tests;
+
+use Cron\CronExpression;
+use PHPUnit\Framework\TestCase;
+
+class DaylightSavingsTest extends TestCase
+{
+    public function testIssue111(): void
+    {
+        $expression = "0 1 * * 0";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("Europe/London");
+
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+
+        $dtCurrent = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-28 14:55:03", $tz);
+        $dtActual = $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName());
+        $this->assertEquals($dtExpected, $dtActual);
+
+        $dtCurrent = $this->createDateTimeExactly("2021-04-21 00:00+01:00", $tz);
+        $dtActual = $cron->getPreviousRunDate($dtCurrent, 3, true, $tz->getName());
+        $this->assertEquals($dtExpected, $dtActual);
+    }
+
+    public function testIssue112(): void
+    {
+        $expression = "15 2 * * 0";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("America/Winnipeg");
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-08 08:15-06:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-14 03:15-05:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent));
+    }
+
+    /**
+     * Create a DateTimeImmutable that represents the given exact moment in time.
+     * This is a bit finicky because DateTime likes to override the timezone with the offset even when it's valid
+     *  and in some cases necessary during DST changes.
+     * Assertions verify no unexpected behavior changes in PHP.
+     */
+    protected function createDateTimeExactly($dtString, \DateTimeZone $timezone)
+    {
+        $dt = \DateTimeImmutable::createFromFormat("!Y-m-d H:iO", $dtString, $timezone);
+        $dt = $dt->setTimezone($timezone);
+        $this->assertEquals($dtString, $dt->format("Y-m-d H:iP"));
+        $this->assertEquals($timezone->getName(), $dt->format("e"));
+        return $dt;
+    }
+
+    public function testOffsetIncrementsNextRunDate(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $cron = new CronExpression("0 1 * * 0");
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-21 00:00+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-21 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-21 02:00+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 00:00+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, true, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-04-04 01:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 02:05+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-04-04 01:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+    }
+
+    public function testOffsetIncrementsPreviousRunDate(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $cron = new CronExpression("0 1 * * 0");
+
+        $dtCurrent = $this->createDateTimeExactly("2021-04-04 02:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-04-04 01:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-04-04 00:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 03:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-21 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 03:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, true, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 00:00+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-21 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+    }
+
+    public function testOffsetDecrementsNextRunDateAllowCurrent(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $cron = new CronExpression("0 1 * * 0");
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-18 00:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-18 01:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, true, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-18 01:05+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, true, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 00:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, true, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 01:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, true, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, true, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 01:05+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-11-01 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, true, $tz->getName()));
+    }
+
+    /**
+     * The fact that crons will run twice using this setup is expected.
+     * This can be avoided by using disallowing the current date or with additional checks outside this library
+     */
+    public function testOffsetDecrementsNextRunDateDisallowCurrent(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $cron = new CronExpression("0 1 * * 0");
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-18 00:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-18 01:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-18 01:05+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 00:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 01:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 01:05+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-11-01 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 01:05+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2020-11-01 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getNextRunDate($dtCurrent, 0, false, $tz->getName()));
+    }
+
+    public function testOffsetDecrementsPreviousRunDate(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $cron = new CronExpression("0 1 * * 0");
+
+        $dtCurrent = $this->createDateTimeExactly("2021-04-04 02:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-04-04 01:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-04-04 00:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 03:00+01:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 00:00+00:00", $tz);
+        $dtExpected = $this->createDateTimeExactly("2021-03-21 01:00+00:00", $tz);
+        $this->assertEquals($dtExpected, $cron->getPreviousRunDate($dtCurrent, 0, false, $tz->getName()));
+    }
+
+    public function testOffsetIncrementsMultipleRunDates(): void
+    {
+        $expression = "0 1 * * 0";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("Europe/London");
+
+        $expected = [
+            $this->createDateTimeExactly("2021-03-14 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2021-03-21 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz),
+            $this->createDateTimeExactly("2021-04-04 01:00+01:00", $tz),
+            $this->createDateTimeExactly("2021-04-11 01:00+01:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-13 00:00+00:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $dtCurrent = $this->createDateTimeExactly("2021-04-12 00:00+01:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+    }
+
+    public function testOffsetDecrementsMultipleRunDates(): void
+    {
+        $expression = "0 1 * * 0";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("Europe/London");
+
+        $expected = [
+            $this->createDateTimeExactly("2020-10-11 01:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-18 01:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-11-01 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-11-08 01:00+00:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-10 00:00+01:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $expected = [
+            $this->createDateTimeExactly("2020-10-18 01:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 01:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-11-01 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-11-08 01:00+00:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2020-11-12 00:00+00:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+    }
+
+    public function testOffsetIncrementsEveryOtherHour(): void
+    {
+        $expression = "0 */2 * * *";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("Europe/London");
+
+        $expected = [
+            $this->createDateTimeExactly("2021-03-27 22:00+00:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 00:00+00:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 04:00+01:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 06:00+01:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-27 22:00+00:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 06:00+01:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $expression = "0 1-23/2 * * *";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("Europe/London");
+
+        $expected = [
+            $this->createDateTimeExactly("2021-03-27 23:00+00:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 02:00+01:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 03:00+01:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 05:00+01:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 07:00+01:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-27 23:00+00:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 07:00+01:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+    }
+
+    public function testOffsetDecrementsEveryOtherHour(): void
+    {
+        $expression = "0 */2 * * *";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("Europe/London");
+
+        $expected = [
+            $this->createDateTimeExactly("2020-10-24 22:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 00:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 02:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 04:00+00:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-24 22:00+01:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $expected = [
+            $this->createDateTimeExactly("2020-10-24 20:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-24 22:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 00:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 02:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 04:00+00:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 04:00+00:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $expression = "0 1-23/2 * * *";
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("Europe/London");
+
+        $expected = [
+            $this->createDateTimeExactly("2020-10-24 23:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 03:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 05:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 07:00+00:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-24 23:00+01:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $expected = [
+            $this->createDateTimeExactly("2020-10-25 01:00+01:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 01:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 03:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 05:00+00:00", $tz),
+            $this->createDateTimeExactly("2020-10-25 07:00+00:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-25 07:00+00:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+    }
+
+    public function testOffsetIncrementsMidnight(): void
+    {
+        $expression = '@hourly';
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("America/Asuncion");
+
+        $expected = [
+            $this->createDateTimeExactly("2021-03-27 22:00-03:00", $tz),
+            $this->createDateTimeExactly("2021-03-27 23:00-03:00", $tz),
+            $this->createDateTimeExactly("2021-03-27 23:00-04:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 00:00-04:00", $tz),
+            $this->createDateTimeExactly("2021-03-28 01:00-04:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-27 22:00-03:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $dtCurrent = $this->createDateTimeExactly("2021-03-28 01:00-04:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+    }
+
+    public function testOffsetDecrementsMidnight(): void
+    {
+        $expression = '@hourly';
+        $cron = new CronExpression($expression);
+        $tz = new \DateTimeZone("America/Asuncion");
+
+        $expected = [
+            $this->createDateTimeExactly("2020-10-03 22:00-04:00", $tz),
+            $this->createDateTimeExactly("2020-10-03 23:00-04:00", $tz),
+            $this->createDateTimeExactly("2020-10-04 01:00-03:00", $tz),
+            $this->createDateTimeExactly("2020-10-04 02:00-03:00", $tz),
+            $this->createDateTimeExactly("2020-10-04 03:00-03:00", $tz),
+        ];
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-03 22:00-04:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, false, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+
+        $dtCurrent = $this->createDateTimeExactly("2020-10-04 03:00-03:00", $tz);
+        $actual = $cron->getMultipleRunDates(5, $dtCurrent, true, true, $tz->getName());
+        foreach ($expected as $dtExpected) {
+            $this->assertContainsEquals($dtExpected, $actual);
+        }
+    }
+}

--- a/tests/Cron/FieldFactoryTest.php
+++ b/tests/Cron/FieldFactoryTest.php
@@ -29,7 +29,7 @@ class FieldFactoryTest extends TestCase
         $f = new FieldFactory();
 
         foreach ($mappings as $position => $class) {
-            $this->assertSame($class, \get_class($f->getField($position)));
+            $this->assertInstanceOf($class, $f->getField($position));
         }
     }
 

--- a/tests/Cron/FieldFactoryTest.php
+++ b/tests/Cron/FieldFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\FieldFactory;
@@ -15,24 +17,24 @@ class FieldFactoryTest extends TestCase
      */
     public function testRetrievesFieldInstances()
     {
-        $mappings = array(
+        $mappings = [
             0 => 'Cron\MinutesField',
             1 => 'Cron\HoursField',
             2 => 'Cron\DayOfMonthField',
             3 => 'Cron\MonthField',
             4 => 'Cron\DayOfWeekField',
-        );
+        ];
 
         $f = new FieldFactory();
 
         foreach ($mappings as $position => $class) {
-            $this->assertSame($class, get_class($f->getField($position)));
+            $this->assertSame($class, \get_class($f->getField($position)));
         }
     }
 
     /**
      * @covers \Cron\FieldFactory::getField
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testValidatesFieldPosition()
     {

--- a/tests/Cron/FieldFactoryTest.php
+++ b/tests/Cron/FieldFactoryTest.php
@@ -16,7 +16,7 @@ class FieldFactoryTest extends TestCase
     /**
      * @covers \Cron\FieldFactory::getField
      */
-    public function testRetrievesFieldInstances()
+    public function testRetrievesFieldInstances(): void
     {
         $mappings = [
             0 => 'Cron\MinutesField',
@@ -36,7 +36,7 @@ class FieldFactoryTest extends TestCase
     /**
      * @covers \Cron\FieldFactory::getField
      */
-    public function testValidatesFieldPosition()
+    public function testValidatesFieldPosition(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $f = new FieldFactory();

--- a/tests/Cron/FieldFactoryTest.php
+++ b/tests/Cron/FieldFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cron\Tests;
 
 use Cron\FieldFactory;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,10 +35,10 @@ class FieldFactoryTest extends TestCase
 
     /**
      * @covers \Cron\FieldFactory::getField
-     * @expectedException \InvalidArgumentException
      */
     public function testValidatesFieldPosition()
     {
+        $this->expectException(InvalidArgumentException::class);
         $f = new FieldFactory();
         $f->getField(-1);
     }

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\HoursField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +23,17 @@ class HoursFieldTest extends TestCase
         $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
-     }
+    }
+
+    /**
+     * @covers \Cron\HoursField::isSatisfiedBy
+     */
+    public function testChecksIfSatisfied()
+    {
+        $f = new HoursField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+    }
 
     /**
      * @covers \Cron\HoursField::increment
@@ -37,6 +48,17 @@ class HoursFieldTest extends TestCase
         $d->setTime(11, 15, 0);
         $f->increment($d, true);
         $this->assertSame('2011-03-15 10:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\HoursField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new HoursField();
+        $f->increment($d);
+        $this->assertSame('2011-03-15 12:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -18,6 +18,8 @@ class HoursFieldTest extends TestCase
     {
         $f = new HoursField();
         $this->assertTrue($f->validate('1'));
+        $this->assertTrue($f->validate('00'));
+        $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
      }

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -24,7 +24,7 @@ class HoursFieldTest extends TestCase
         $this->assertTrue($f->validate('00'));
         $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('*'));
-        $this->assertFalse($f->validate('*/3,1,1-12'));
+        $this->assertTrue($f->validate('*/3,1,1-12'));
         $this->assertFalse($f->validate('1/10'));
     }
 

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -93,7 +93,30 @@ class HoursFieldTest extends TestCase
     /**
      * @covers \Cron\HoursField::increment
      */
-    public function testIncrementAcrossDstChange(): void
+    public function testIncrementAcrossDstChangeBerlin(): void
+    {
+        $tz = new \DateTimeZone("Europe/Berlin");
+        $d = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-27 23:00:00", $tz);
+        $f = new HoursField();
+        $f->increment($d);
+        $this->assertSame("2021-03-28 00:00:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d);
+        $this->assertSame("2021-03-28 01:00:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d);
+        $this->assertSame("2021-03-28 03:00:00", $d->format("Y-m-d H:i:s"));
+
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 01:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 00:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-27 23:59:00", $d->format("Y-m-d H:i:s"));
+    }
+
+    /**
+     * @covers \Cron\HoursField::increment
+     */
+    public function testIncrementAcrossDstChangeLondon(): void
     {
         $tz = new \DateTimeZone("Europe/London");
         $d = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-27 23:00:00", $tz);

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -27,7 +27,7 @@ class HoursFieldTest extends TestCase
         $this->assertFalse($f->validate('*/3,1,1-12'));
     }
 
-        /**
+    /**
      * @covers \Cron\HoursField::increment
      */
     public function testIncrementsDate()

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -17,7 +17,7 @@ class HoursFieldTest extends TestCase
     /**
      * @covers \Cron\HoursField::validate
      */
-    public function testValidatesField()
+    public function testValidatesField(): void
     {
         $f = new HoursField();
         $this->assertTrue($f->validate('1'));
@@ -31,7 +31,7 @@ class HoursFieldTest extends TestCase
     /**
      * @covers \Cron\HoursField::increment
      */
-    public function testIncrementsDate()
+    public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
         $f = new HoursField();
@@ -46,7 +46,7 @@ class HoursFieldTest extends TestCase
     /**
      * @covers \Cron\HoursField::increment
      */
-    public function testIncrementsDateTimeImmutable()
+    public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
         $f = new HoursField();
@@ -57,7 +57,7 @@ class HoursFieldTest extends TestCase
     /**
      * @covers \Cron\HoursField::increment
      */
-    public function testIncrementsDateWithThirtyMinuteOffsetTimezone()
+    public function testIncrementsDateWithThirtyMinuteOffsetTimezone(): void
     {
         $tz = date_default_timezone_get();
         date_default_timezone_set('America/St_Johns');
@@ -75,7 +75,7 @@ class HoursFieldTest extends TestCase
     /**
      * @covers \Cron\HoursField::increment
      */
-    public function testIncrementDateWithFifteenMinuteOffsetTimezone()
+    public function testIncrementDateWithFifteenMinuteOffsetTimezone(): void
     {
         $tz = date_default_timezone_get();
         date_default_timezone_set('Asia/Kathmandu');

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\HoursField;
@@ -22,7 +24,7 @@ class HoursFieldTest extends TestCase
         $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
-     }
+    }
 
     /**
      * @covers \Cron\HoursField::increment

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -89,4 +89,27 @@ class HoursFieldTest extends TestCase
         $this->assertSame('2011-03-15 10:59:00', $d->format('Y-m-d H:i:s'));
         date_default_timezone_set($tz);
     }
+
+    /**
+     * @covers \Cron\HoursField::increment
+     */
+    public function testIncrementAcrossDstChange(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $d = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-27 23:00:00", $tz);
+        $f = new HoursField();
+        $f->increment($d);
+        $this->assertSame("2021-03-28 00:00:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d);
+        $this->assertSame("2021-03-28 02:00:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d);
+        $this->assertSame("2021-03-28 03:00:00", $d->format("Y-m-d H:i:s"));
+
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 02:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 00:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-27 23:59:00", $d->format("Y-m-d H:i:s"));
+    }
 }

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -27,17 +27,7 @@ class HoursFieldTest extends TestCase
         $this->assertFalse($f->validate('*/3,1,1-12'));
     }
 
-    /**
-     * @covers \Cron\HoursField::isSatisfiedBy
-     */
-    public function testChecksIfSatisfied()
-    {
-        $f = new HoursField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
-    }
-
-    /**
+        /**
      * @covers \Cron\HoursField::increment
      */
     public function testIncrementsDate()

--- a/tests/Cron/HoursFieldTest.php
+++ b/tests/Cron/HoursFieldTest.php
@@ -25,6 +25,7 @@ class HoursFieldTest extends TestCase
         $this->assertTrue($f->validate('01'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
+        $this->assertFalse($f->validate('1/10'));
     }
 
         /**

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\MinutesField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,6 +24,16 @@ class MinutesFieldTest extends TestCase
     }
 
     /**
+     * @covers \Cron\MinutesField::isSatisfiedBy
+     */
+    public function testChecksIfSatisfied()
+    {
+        $f = new MinutesField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+    }
+
+    /**
      * @covers \Cron\MinutesField::increment
      */
     public function testIncrementsDate()
@@ -33,6 +44,17 @@ class MinutesFieldTest extends TestCase
         $this->assertSame('2011-03-15 11:16:00', $d->format('Y-m-d H:i:s'));
         $f->increment($d, true);
         $this->assertSame('2011-03-15 11:15:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\MinutesField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new MinutesField();
+        $f->increment($d);
+        $this->assertSame('2011-03-15 11:16:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -22,7 +22,7 @@ class MinutesFieldTest extends TestCase
         $f = new MinutesField();
         $this->assertTrue($f->validate('1'));
         $this->assertTrue($f->validate('*'));
-        $this->assertFalse($f->validate('*/3,1,1-12'));
+        $this->assertTrue($f->validate('*/3,1,1-12'));
         $this->assertFalse($f->validate('1/10'));
     }
 

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -23,6 +23,7 @@ class MinutesFieldTest extends TestCase
         $this->assertTrue($f->validate('1'));
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/3,1,1-12'));
+        $this->assertFalse($f->validate('1/10'));
     }
 
     /**

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -17,7 +17,7 @@ class MinutesFieldTest extends TestCase
     /**
      * @covers \Cron\MinutesField::validate
      */
-    public function testValidatesField()
+    public function testValidatesField(): void
     {
         $f = new MinutesField();
         $this->assertTrue($f->validate('1'));
@@ -29,7 +29,7 @@ class MinutesFieldTest extends TestCase
     /**
      * @covers \Cron\MinutesField::isSatisfiedBy
      */
-    public function testChecksIfSatisfied()
+    public function testChecksIfSatisfied(): void
     {
         $f = new MinutesField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
@@ -39,7 +39,7 @@ class MinutesFieldTest extends TestCase
     /**
      * @covers \Cron\MinutesField::increment
      */
-    public function testIncrementsDate()
+    public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
         $f = new MinutesField();
@@ -52,7 +52,7 @@ class MinutesFieldTest extends TestCase
     /**
      * @covers \Cron\MinutesField::increment
      */
-    public function testIncrementsDateTimeImmutable()
+    public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
         $f = new MinutesField();
@@ -67,7 +67,7 @@ class MinutesFieldTest extends TestCase
      *
      * @since 2017-08-18
      */
-    public function testBadSyntaxesShouldNotValidate()
+    public function testBadSyntaxesShouldNotValidate(): void
     {
         $f = new MinutesField();
         $this->assertFalse($f->validate('*-1'));
@@ -83,7 +83,7 @@ class MinutesFieldTest extends TestCase
      * @since 2019-07-29
      * @see https://github.com/dragonmantank/cron-expression/issues/18
      */
-    public function testInvalidRangeShouldNotValidate()
+    public function testInvalidRangeShouldNotValidate(): void
     {
         $f = new MinutesField();
         $this->assertFalse($f->validate('0/5'));

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\MinutesField;
@@ -39,6 +41,7 @@ class MinutesFieldTest extends TestCase
      * Various bad syntaxes that are reported to work, but shouldn't.
      *
      * @author Chris Tankersley
+     *
      * @since 2017-08-18
      */
     public function testBadSyntaxesShouldNotValidate()

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -74,4 +74,18 @@ class MinutesFieldTest extends TestCase
         $this->assertFalse($f->validate('1-2-3'));
         $this->assertFalse($f->validate('-1'));
     }
+
+    /**
+     * Ranges that are invalid should not validate.
+     * In this case `0/5` would be invalid because `0` is not part of the minute range.
+     *
+     * @author Chris Tankersley
+     * @since 2019-07-29
+     * @see https://github.com/dragonmantank/cron-expression/issues/18
+     */
+    public function testInvalidRangeShouldNotValidate()
+    {
+        $f = new MinutesField();
+        $this->assertFalse($f->validate('0/5'));
+    }
 }

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -89,4 +89,42 @@ class MinutesFieldTest extends TestCase
         $f = new MinutesField();
         $this->assertFalse($f->validate('0/5'));
     }
+
+    /**
+     * @covers \Cron\MinutesField::increment
+     */
+    public function testIncrementAcrossDstChangeBerlin(): void
+    {
+        $tz = new \DateTimeZone("Europe/Berlin");
+        $d = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-28 01:59:00", $tz);
+        $f = new MinutesField();
+        $f->increment($d);
+        $this->assertSame("2021-03-28 03:00:00", $d->format("Y-m-d H:i:s"));
+
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 01:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 01:58:00", $d->format("Y-m-d H:i:s"));
+    }
+
+    /**
+     * @covers \Cron\MinutesField::increment
+     */
+    public function testIncrementAcrossDstChangeLondon(): void
+    {
+        $tz = new \DateTimeZone("Europe/London");
+        $d = \DateTimeImmutable::createFromFormat("!Y-m-d H:i:s", "2021-03-28 00:59:00", $tz);
+        $f = new MinutesField();
+        $f->increment($d);
+        $this->assertSame("2021-03-28 02:00:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d);
+        $this->assertSame("2021-03-28 02:01:00", $d->format("Y-m-d H:i:s"));
+
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 02:00:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 00:59:00", $d->format("Y-m-d H:i:s"));
+        $f->increment($d, true);
+        $this->assertSame("2021-03-28 00:58:00", $d->format("Y-m-d H:i:s"));
+    }
 }

--- a/tests/Cron/MinutesFieldTest.php
+++ b/tests/Cron/MinutesFieldTest.php
@@ -32,8 +32,8 @@ class MinutesFieldTest extends TestCase
     public function testChecksIfSatisfied(): void
     {
         $f = new MinutesField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
     /**
@@ -45,6 +45,7 @@ class MinutesFieldTest extends TestCase
         $f = new MinutesField();
         $f->increment($d);
         $this->assertSame('2011-03-15 11:16:00', $d->format('Y-m-d H:i:s'));
+
         $f->increment($d, true);
         $this->assertSame('2011-03-15 11:15:00', $d->format('Y-m-d H:i:s'));
     }

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -4,6 +4,7 @@ namespace Cron\Tests;
 
 use Cron\MonthField;
 use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,6 +25,16 @@ class MonthFieldTest extends TestCase
     }
 
     /**
+     * @covers \Cron\MonthField::isSatisfiedBy
+     */
+    public function testChecksIfSatisfied()
+    {
+        $f = new MonthField();
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+    }
+
+    /**
      * @covers \Cron\MonthField::increment
      */
     public function testIncrementsDate()
@@ -36,6 +47,17 @@ class MonthFieldTest extends TestCase
         $d = new DateTime('2011-03-15 11:15:00');
         $f->increment($d, true);
         $this->assertSame('2011-02-28 23:59:00', $d->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @covers \Cron\MonthField::increment
+     */
+    public function testIncrementsDateTimeImmutable()
+    {
+        $d = new DateTimeImmutable('2011-03-15 11:15:00');
+        $f = new MonthField();
+        $f->increment($d);
+        $this->assertSame('2011-04-01 00:00:00', $d->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -22,7 +22,7 @@ class MonthFieldTest extends TestCase
         $f = new MonthField();
         $this->assertTrue($f->validate('12'));
         $this->assertTrue($f->validate('*'));
-        $this->assertFalse($f->validate('*/10,2,1-12'));
+        $this->assertTrue($f->validate('*/10,2,1-12'));
         $this->assertFalse($f->validate('1.fix-regexp'));
         $this->assertFalse($f->validate('1/10'));
     }

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -33,8 +33,8 @@ class MonthFieldTest extends TestCase
     public function testChecksIfSatisfied(): void
     {
         $f = new MonthField();
-        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
-        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?'));
+        $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?', false));
+        $this->assertTrue($f->isSatisfiedBy(new DateTimeImmutable(), '?', false));
     }
 
     /**

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -102,4 +102,19 @@ class MonthFieldTest extends TestCase
         $f->increment($d, true);
         $this->assertSame('2010-12-31 23:59:00', $d->format('Y-m-d H:i:s'));
     }
+
+    /**
+     * Incoming literals should ignore case
+     *
+     * @author Chris Tankersley <chris@ctankersley.com?
+     * @since 2019-07-29
+     * @see https://github.com/dragonmantank/cron-expression/issues/24
+     */
+    public function testLiteralsIgnoreCasingProperly()
+    {
+        $f = new MonthField();
+        $this->assertTrue($f->validate('JAN'));
+        $this->assertTrue($f->validate('Jan'));
+        $this->assertTrue($f->validate('jan'));
+    }
 }

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -24,6 +24,7 @@ class MonthFieldTest extends TestCase
         $this->assertTrue($f->validate('*'));
         $this->assertFalse($f->validate('*/10,2,1-12'));
         $this->assertFalse($f->validate('1.fix-regexp'));
+        $this->assertFalse($f->validate('1/10'));
     }
 
     /**

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cron\Tests;
 
 use Cron\MonthField;
@@ -55,7 +57,6 @@ class MonthFieldTest extends TestCase
         $this->assertSame('2011-02-28 23:59:00', $d->format('Y-m-d H:i:s'));
         date_default_timezone_set($tz);
     }
-
 
     /**
      * @covers \Cron\MonthField::increment

--- a/tests/Cron/MonthFieldTest.php
+++ b/tests/Cron/MonthFieldTest.php
@@ -17,7 +17,7 @@ class MonthFieldTest extends TestCase
     /**
      * @covers \Cron\MonthField::validate
      */
-    public function testValidatesField()
+    public function testValidatesField(): void
     {
         $f = new MonthField();
         $this->assertTrue($f->validate('12'));
@@ -30,7 +30,7 @@ class MonthFieldTest extends TestCase
     /**
      * @covers \Cron\MonthField::isSatisfiedBy
      */
-    public function testChecksIfSatisfied()
+    public function testChecksIfSatisfied(): void
     {
         $f = new MonthField();
         $this->assertTrue($f->isSatisfiedBy(new DateTime(), '?'));
@@ -40,7 +40,7 @@ class MonthFieldTest extends TestCase
     /**
      * @covers \Cron\MonthField::increment
      */
-    public function testIncrementsDate()
+    public function testIncrementsDate(): void
     {
         $d = new DateTime('2011-03-15 11:15:00');
         $f = new MonthField();
@@ -55,7 +55,7 @@ class MonthFieldTest extends TestCase
     /**
      * @covers \Cron\MonthField::increment
      */
-    public function testIncrementsDateTimeImmutable()
+    public function testIncrementsDateTimeImmutable(): void
     {
         $d = new DateTimeImmutable('2011-03-15 11:15:00');
         $f = new MonthField();
@@ -66,7 +66,7 @@ class MonthFieldTest extends TestCase
     /**
      * @covers \Cron\MonthField::increment
      */
-    public function testIncrementsDateWithThirtyMinuteTimezone()
+    public function testIncrementsDateWithThirtyMinuteTimezone(): void
     {
         $tz = date_default_timezone_get();
         date_default_timezone_set('America/St_Johns');
@@ -84,7 +84,7 @@ class MonthFieldTest extends TestCase
     /**
      * @covers \Cron\MonthField::increment
      */
-    public function testIncrementsYearAsNeeded()
+    public function testIncrementsYearAsNeeded(): void
     {
         $f = new MonthField();
         $d = new DateTime('2011-12-15 00:00:00');
@@ -95,7 +95,7 @@ class MonthFieldTest extends TestCase
     /**
      * @covers \Cron\MonthField::increment
      */
-    public function testDecrementsYearAsNeeded()
+    public function testDecrementsYearAsNeeded(): void
     {
         $f = new MonthField();
         $d = new DateTime('2011-01-15 00:00:00');
@@ -110,7 +110,7 @@ class MonthFieldTest extends TestCase
      * @since 2019-07-29
      * @see https://github.com/dragonmantank/cron-expression/issues/24
      */
-    public function testLiteralsIgnoreCasingProperly()
+    public function testLiteralsIgnoreCasingProperly(): void
     {
         $f = new MonthField();
         $this->assertTrue($f->validate('JAN'));


### PR DESCRIPTION
In my use of this repository, it would be very useful (is useful) to have a static function called isValid that simply returns TRUE or FALSE if the cronExpression is valid.